### PR TITLE
Fix: 회원가입 로직 에러 수정

### DIFF
--- a/src/components/Modal/Nickname/Nickname.tsx
+++ b/src/components/Modal/Nickname/Nickname.tsx
@@ -28,33 +28,6 @@ export default function Nickname() {
     },
   });
 
-  const registerMutation = useMutation({
-    mutationFn: async (data: { provider: string; providerAccessToken: string; name: string }) => {
-      const response = await axiosInstance.post("/auth/register", data);
-      return response.data;
-    },
-    onSuccess: (data) => {
-      setAuth({
-        access_token: data.accessToken,
-        isLoggedIn: true,
-        user_id: data.id,
-      });
-
-      localStorage.setItem("access_token", data.accessToken);
-      localStorage.setItem("refresh_token", data.refreshToken || "");
-
-      setModal({ isOpen: true, type: "JOIN", data: null });
-    },
-    onError: (error: any) => {
-      if (error?.response?.status === 409) {
-        setErrorMessage("이미 사용 중인 활동명입니다.");
-      } else {
-        console.error("Registration error:", error);
-        showToast("오류가 발생했습니다. 다시 시도해주세요.", "error");
-      }
-    },
-  });
-
   const handleSubmitNickname = async () => {
     setErrorMessage("");
 
@@ -88,6 +61,15 @@ export default function Nickname() {
     } catch (error) {}
   };
 
+  const handleEnterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return;
+
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      handleSubmitNickname();
+    }
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.titleContainer}>
@@ -104,6 +86,7 @@ export default function Nickname() {
               setNickname(e.target.value.trimStart());
               setErrorMessage("");
             }}
+            onKeyDown={handleEnterKeyDown}
             isError={!!errorMessage || checkNicknameMutation.isError}
             errorMessage={errorMessage}
           />


### PR DESCRIPTION
### 🔎 작업 내용
> Issue #5 
- 닉네임과 id API 호출을 모달별로 완전히 분리
- 엔터 눌러도 입력되도록 수정
- 프로필 URL (id) 중복 메시지 제대로 렌더링되도록 수정

### 📸 스크린샷
<img width="758" alt="스크린샷 2025-03-19 오후 5 03 41" src="https://github.com/user-attachments/assets/2aa43de4-4a11-4d66-b48d-621da724b742" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
