### PR TITLE
Fix: 회원 탈퇴 시 로컬스토리지 초기화 문제 해결

### DIFF
--- a/src/api/users/deleteMe.ts
+++ b/src/api/users/deleteMe.ts
@@ -1,12 +1,19 @@
 import axiosInstance from "@/constants/baseurl";
 
 export async function deleteMe(): Promise<Response> {
-  const response = await axiosInstance.delete("/users/me");
+  try {
+    const response = await axiosInstance.delete("/users/me", {
+      headers: {
+        "is-delete-account": "true",
+      },
+    });
 
-  if (response.status === 200) {
     localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
     localStorage.removeItem("user_id");
-  }
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
 }

--- a/src/components/ProfilePage/Profile/Profile.tsx
+++ b/src/components/ProfilePage/Profile/Profile.tsx
@@ -26,6 +26,7 @@ import { deleteMe } from "@/api/users/deleteMe";
 
 export default function Profile({ isMyProfile, id }: ProfileProps) {
   const { isLoggedIn, user_id } = useRecoilValue(authState);
+  const [, setAuth] = useRecoilState(authState);
   const [, setModal] = useRecoilState(modalState);
   const { data: myData, refetch } = useMyData();
   const { data: userData, refetch: refetchUserData } = useUserData(id);
@@ -303,6 +304,11 @@ export default function Profile({ isMyProfile, id }: ProfileProps) {
           onClick: async () => {
             try {
               await deleteMe();
+              setAuth({
+                access_token: "",
+                isLoggedIn: false,
+                user_id: "",
+              });
               showToast("회원 탈퇴 되었습니다.", "success");
               router.push("/");
             } catch (err) {

--- a/src/constants/baseurl.tsx
+++ b/src/constants/baseurl.tsx
@@ -27,9 +27,19 @@ axiosInstance.interceptors.request.use(
 );
 
 axiosInstance.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    if (response.config.headers["is-delete-account"] === "true") {
+      return response;
+    }
+    return response;
+  },
+
   async (error) => {
     const originalRequest = error.config;
+
+    if (originalRequest.headers["is-delete-account"] === "true") {
+      return Promise.reject(error);
+    }
 
     if (error.response?.status === 401) {
       const refreshToken = localStorage.getItem("refresh_token");


### PR DESCRIPTION
### 🔎 작업 내용

- close #4

- [x] 회원탈퇴시 authState와 refreashToken 초기화
  - [x] refreashToken이 인터셉터 요청에 의해 탈퇴처리해도 재갱신됨을 확인
  - [x] 그냥 삭제 요청에 `is-delete-account`헤더를 추가해서 플래그로 사용하고, 401 에러가 발생하더라도 토큰 갱신을 시도하지 않도록 변경

### 📸 스크린샷
<img width="448" alt="스크린샷 2025-03-19 오후 10 14 37" src="https://github.com/user-attachments/assets/ba962137-a118-4f4f-b9ea-6423e1af0c9e" />


### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
