### PR TITLE
Refactor: 관련 작품 및 헤더 검색창 웹뷰 토글 로직 삭제

### DIFF
--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -444,7 +444,7 @@ export default function Detail({ id }: DetailProps) {
             <div className={styles.bar} />
             <div className={styles.cards}>
               <Author authorId={details.author.id} feedId={id} authorUrl={details.author.url} />
-              {details.tags.length > 0 && <Similar tagNames={details.tags.join(",")} />}
+              {/* {details.tags.length > 0 && <Similar tagNames={details.tags.join(",")} />} */}
               <NewFeed isDetail />
             </div>
           </>

--- a/src/components/Detail/Similar/Similar.tsx
+++ b/src/components/Detail/Similar/Similar.tsx
@@ -20,7 +20,7 @@ export default function Similar({ tagNames }: SimilarProps) {
 
   return (
     <div className={styles.container}>
-      <Title>관련 작품</Title>
+      {/* <Title>관련 작품</Title>
       {Data && (
         <div className={styles.cardList}>
           {Data.map((item) => (
@@ -36,7 +36,7 @@ export default function Similar({ tagNames }: SimilarProps) {
             />
           ))}
         </div>
-      )}
+      )} */}
     </div>
   );
 }

--- a/src/components/Detail/Similar/Similar.tsx
+++ b/src/components/Detail/Similar/Similar.tsx
@@ -20,7 +20,7 @@ export default function Similar({ tagNames }: SimilarProps) {
 
   return (
     <div className={styles.container}>
-      {/* <Title>관련 작품</Title>
+      <Title>관련 작품</Title>
       {Data && (
         <div className={styles.cardList}>
           {Data.map((item) => (
@@ -36,7 +36,7 @@ export default function Similar({ tagNames }: SimilarProps) {
             />
           ))}
         </div>
-      )} */}
+      )}
     </div>
   );
 }

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -26,7 +26,6 @@ export default function Header() {
   const [activeNav, setActiveNav] = useState("홈");
   const activeItemRef = useRef<HTMLDivElement>(null);
   const indicatorRef = useRef<HTMLDivElement>(null);
-  const [isSearchBarOpen, setIsSearchBarOpen] = useState(false);
   const [keyword, setKeyword] = useState("");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -205,10 +204,6 @@ export default function Header() {
     }
   };
 
-  const handleSearchBarOpen = () => {
-    setIsSearchBarOpen((prev) => !prev);
-  };
-
   const toggleNotifications = () => {
     setShowNotifications((prev) => !prev);
   };
@@ -243,7 +238,7 @@ export default function Header() {
         tab = "board";
       }
       router.push(`/search?tab=${tab}&keyword=${encodeURIComponent(trimmedKeyword)}`);
-      setIsSearchBarOpen(false);
+      // setIsSearchBarOpen(false);
       setKeyword("");
     }
   };
@@ -292,37 +287,26 @@ export default function Header() {
           )}
           <div className={styles.icons}>
             {!isMobile && !isTablet ? (
-              isSearchBarOpen ? (
-                <div className={styles.searchbarContainer}>
-                  <input
-                    placeholder="그림, 작가, 관련 작품을 검색해보세요"
-                    className={styles.input}
-                    value={keyword}
-                    onChange={(e) => setKeyword(e.target.value)}
-                    onKeyDown={handleSearchKeyDown}
-                  />
-                  <div onClick={handleSearchBarOpen}>
-                    <IconComponent name="searchGray" size={24} padding={8} isBtn />
-                  </div>
-                </div>
-              ) : (
-                <div onClick={handleSearchBarOpen}>
+              <div className={styles.searchbarContainer}>
+                <input
+                  placeholder="그림, 작가, 관련 작품을 검색해보세요"
+                  className={styles.input}
+                  value={keyword}
+                  onChange={(e) => setKeyword(e.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                />
+                <Link href="/search">
                   <IconComponent
                     name={isUserPage ? "searchWhite" : "search"}
                     size={24}
                     padding={8}
                     isBtn
                   />
-                </div>
-              )
+                </Link>
+              </div>
             ) : (
               <Link href="/search">
-                <IconComponent
-                  name={isUserPage ? "searchWhite" : "search"}
-                  size={24}
-                  padding={8}
-                  isBtn
-                />
+                <IconComponent name="search" size={24} padding={8} isBtn />
               </Link>
             )}
             {isLoggedIn && myData && (

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -238,7 +238,6 @@ export default function Header() {
         tab = "board";
       }
       router.push(`/search?tab=${tab}&keyword=${encodeURIComponent(trimmedKeyword)}`);
-      // setIsSearchBarOpen(false);
       setKeyword("");
     }
   };
@@ -286,29 +285,9 @@ export default function Header() {
             </div>
           )}
           <div className={styles.icons}>
-            {!isMobile && !isTablet ? (
-              <div className={styles.searchbarContainer}>
-                <input
-                  placeholder="그림, 작가, 관련 작품을 검색해보세요"
-                  className={styles.input}
-                  value={keyword}
-                  onChange={(e) => setKeyword(e.target.value)}
-                  onKeyDown={handleSearchKeyDown}
-                />
-                <Link href="/search">
-                  <IconComponent
-                    name={isUserPage ? "searchWhite" : "search"}
-                    size={24}
-                    padding={8}
-                    isBtn
-                  />
-                </Link>
-              </div>
-            ) : (
-              <Link href="/search">
-                <IconComponent name="search" size={24} padding={8} isBtn />
-              </Link>
-            )}
+            <Link href="/search">
+              <IconComponent name="search" size={24} padding={8} isBtn />
+            </Link>
             {isLoggedIn && myData && (
               <div className={styles.notificationWrapper} ref={notificationRef}>
                 <div className={styles.notification} onClick={toggleNotifications}>


### PR DESCRIPTION
### 🔎 작업 내용

- [x] Similar 주석 처리
- [x] Desktop에서 검색창 아이콘 클릭않고 바로 검색할 수 있도록 수정

### 📸 스크린샷
<img width="1243" alt="스크린샷 2025-03-26 오후 9 29 52" src="https://github.com/user-attachments/assets/b5b6e197-4b81-4e69-90d7-2ce5ad45cd56" />
<img width="346" alt="스크린샷 2025-03-26 오후 9 32 08" src="https://github.com/user-attachments/assets/7ce9a13a-2e70-4f56-a723-032e4ce16282" />


### :loudspeaker: 전달사항
관련 작품은 혹시 몰라서 주석 처리만 했는데, 이로 인해 발생하는 빈 공간이 다소 있습니다. (스크린샷 참조)
필요하다면 임시로 여백을 줄여놓겠습니다!

