### PR TITLE
Refactor: 알림 타입 통일에 따른 리팩토링 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "tinymce": "^7.6.1"
       },
       "devDependencies": {
-        "@grimity/dto": "^1.0.9",
+        "@grimity/dto": "^1.0.11",
         "@grimity/shared-types": "^1.3.0",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@grimity/dto": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@grimity/dto/-/dto-1.0.9.tgz",
-      "integrity": "sha512-qyVrm9YsNciG4BjbpzSdIKi+Ro6cyrIul2NwQXPDwbY7oewY0fsNLjecZ41krBqgfRArmPAVtmHAAcQQR0YJpQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@grimity/dto/-/dto-1.0.11.tgz",
+      "integrity": "sha512-KTA+7JEqdzoddrQ/bQLUGOFU+0cTGR5mFjkuqXHnaHGvZBbBMolHwoboxRZOUHBOLdh4j/rPcHhqNWG2zKLYaQ==",
       "dev": true
     },
     "node_modules/@grimity/shared-types": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tinymce": "^7.6.1"
   },
   "devDependencies": {
-    "@grimity/dto": "^1.0.9",
+    "@grimity/dto": "^1.0.11",
     "@grimity/shared-types": "^1.3.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/components/Notifications/Noti/Noti.tsx
+++ b/src/components/Notifications/Noti/Noti.tsx
@@ -10,6 +10,7 @@ import axios from "axios";
 import { useRouter } from "next/router";
 import { useRecoilValue } from "recoil";
 import { isTabletState } from "@/states/isMobileState";
+import { imageUrl as imagePrefix } from "@/constants/imageUrl";
 
 export default function Noti({ notification, onClose, onRefetch }: NotiProps) {
   const { showToast } = useToast();
@@ -22,7 +23,7 @@ export default function Noti({ notification, onClose, onRefetch }: NotiProps) {
 
   const renderImage = () => {
     const imageUrl = notification?.image || "/image/default.svg";
-    const isFeedImage = imageUrl.startsWith(`${process.env.NEXT_PUBLIC_IMAGE_URL}/feed`);
+    const isFeedImage = imageUrl.startsWith(`${imagePrefix}/feed`);
 
     if (isFeedImage) {
       return (

--- a/src/components/Notifications/Noti/Noti.tsx
+++ b/src/components/Notifications/Noti/Noti.tsx
@@ -22,7 +22,7 @@ export default function Noti({ notification, onClose, onRefetch }: NotiProps) {
 
   const renderImage = () => {
     const imageUrl = notification?.image || "/image/default.svg";
-    const isFeedImage = imageUrl.startsWith("https://image.grimity.com/feed");
+    const isFeedImage = imageUrl.startsWith(`${process.env.NEXT_PUBLIC_IMAGE_URL}/feed`);
 
     if (isFeedImage) {
       return (
@@ -71,7 +71,7 @@ export default function Noti({ notification, onClose, onRefetch }: NotiProps) {
     e.preventDefault();
 
     try {
-      if (!notification.isRead) await handleReadNotification();
+      if (!notification.isRead) handleReadNotification();
       router.push(notification.link);
     } catch (error) {
       console.error("Notification error:", error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,9 +18,24 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    "next.config.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
### 🔎 작업 내용

> close #19 

- [x] `Notifications` 알림 타입 통일

###  **알림 타입 통일에 따른 이미지 렌더링 수정**
  - [x] 피드 이미지라면 네모, 다른 모든 이미지 URL은 원형으로 조건부 렌더링
  - [x] 사용자 이미지가 null일 경우 기본 이미지를 렌더링

### **예외처리 로직 변경**
 - [x] full path(`nofification.link`)로 이동하도록 변경
 - [x] 해당 알림이 읽지 않음 상태일때만 읽음 처리 api를 호출하도록 변경

### 📸 스크린샷

### :loudspeaker: 전달사항
제가 졸면서 고쳐서.. 에러가 있다면 알려주세요 😳
- 추가한 라이브러리나 특이 사항
