### PR TITLE
Feat: 우클릭 방지 훅 구현 및 이미지에 적용

### DIFF
--- a/src/components/Detail/Author/Author.tsx
+++ b/src/components/Detail/Author/Author.tsx
@@ -14,6 +14,7 @@ import { useUserDataByUrl } from "@/api/users/getId";
 import Button from "@/components/Button/Button";
 import { useUserForDetail } from "@/api/users/getIdFeeds";
 import SquareCard from "@/components/Layout/SquareCard/SquareCard";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import Loader from "@/components/Layout/Loader/Loader";
 import { isMobileState } from "@/states/isMobileState";
 import { useRouter } from "next/router";
@@ -22,6 +23,8 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
   const { data: userData } = useUserData(authorId);
   const { data: userDataByUrl } = useUserDataByUrl(authorUrl);
   const { isLoggedIn, user_id } = useRecoilValue(authState);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
+  const divRef = usePreventRightClick<HTMLDivElement>();
   const [isFollowing, setIsFollowing] = useState(false);
   const [followerCount, setFollowerCount] = useState(0);
   const { showToast } = useToast();
@@ -89,6 +92,7 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   ) : (
                     <Image
@@ -100,6 +104,7 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   )}
                   <div className={styles.authorInfo}>
@@ -137,7 +142,7 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
               </Link>
             )}
           </div>
-          <div className={styles.cardList}>
+          <div className={styles.cardList} ref={divRef}>
             {feeds.map((feed) => (
               <SquareCard
                 key={feed.id}

--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -309,6 +309,7 @@ export default function Detail({ id }: DetailProps) {
                     className={styles.cardImage}
                     onClick={() => handleImageClick(card)}
                     ref={imgRef}
+                    onContextMenu={(e) => e.preventDefault()}
                   />
                   {index === 1 && details.cards.length > 2 && !isExpanded && (
                     <>
@@ -336,6 +337,7 @@ export default function Detail({ id }: DetailProps) {
                       className={styles.cardImage}
                       onClick={() => handleImageClick(card)}
                       ref={imgRef}
+                      onContextMenu={(e) => e.preventDefault()}
                     />
                   </div>
                 ))}

--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -28,6 +28,7 @@ import Comment from "./Comment/Comment";
 import NewFeed from "../Layout/NewFeed/NewFeed";
 import { isMobileState } from "@/states/isMobileState";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function Detail({ id }: DetailProps) {
   const { isLoggedIn, user_id } = useRecoilValue(authState);
@@ -39,6 +40,9 @@ export default function Detail({ id }: DetailProps) {
   const [currentLikeCount, setCurrentLikeCount] = useState(0);
   const [viewCounted, setViewCounted] = useState(false);
   const [overlayImage, setOverlayImage] = useState<string | null>(null);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
+  const divRef = usePreventRightClick<HTMLDivElement>();
+  const sectionRef = usePreventRightClick<HTMLElement>();
   const router = useRouter();
   const [, setModal] = useRecoilState(modalState);
   const isMobile = useRecoilValue(isMobileState);
@@ -223,6 +227,7 @@ export default function Detail({ id }: DetailProps) {
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   ) : (
                     <Image
@@ -234,6 +239,7 @@ export default function Detail({ id }: DetailProps) {
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   )}
                 </Link>
@@ -291,9 +297,9 @@ export default function Detail({ id }: DetailProps) {
                 <ShareBtn feedId={id} title={details.title} image={details.cards[0]} />
               </div>
             </section>
-            <section className={styles.imageGallery}>
+            <section className={styles.imageGallery} ref={sectionRef}>
               {details.cards.slice(0, 2).map((card, index) => (
-                <div key={index} className={styles.imageWrapper}>
+                <div key={index} className={styles.imageWrapper} ref={divRef}>
                   <img
                     src={card}
                     alt={`Card image ${index + 1}`}
@@ -302,6 +308,7 @@ export default function Detail({ id }: DetailProps) {
                     loading="lazy"
                     className={styles.cardImage}
                     onClick={() => handleImageClick(card)}
+                    ref={imgRef}
                   />
                   {index === 1 && details.cards.length > 2 && !isExpanded && (
                     <>
@@ -316,23 +323,26 @@ export default function Detail({ id }: DetailProps) {
                 </div>
               ))}
             </section>
-            {isExpanded &&
-              details.cards.slice(2).map((card, index) => (
-                <div key={index + 2} className={styles.imageWrapper2}>
-                  <img
-                    src={card}
-                    alt={`Card image ${index + 3}`}
-                    width={600}
-                    height={0}
-                    loading="lazy"
-                    className={styles.cardImage}
-                    onClick={() => handleImageClick(card)}
-                  />
-                </div>
-              ))}
+            <section ref={sectionRef}>
+              {isExpanded &&
+                details.cards.slice(2).map((card, index) => (
+                  <div key={index + 2} className={styles.imageWrapper2} ref={divRef}>
+                    <img
+                      src={card}
+                      alt={`Card image ${index + 3}`}
+                      width={600}
+                      height={0}
+                      loading="lazy"
+                      className={styles.cardImage}
+                      onClick={() => handleImageClick(card)}
+                      ref={imgRef}
+                    />
+                  </div>
+                ))}
+            </section>
             {overlayImage && (
               <div className={styles.overlay} onClick={() => setOverlayImage(null)}>
-                <div className={styles.overlayContent}>
+                <div className={styles.overlayContent} ref={divRef}>
                   <Zoom>
                     <img
                       src={overlayImage}
@@ -343,6 +353,7 @@ export default function Detail({ id }: DetailProps) {
                       }}
                       loading="lazy"
                       onClick={(event) => event.stopPropagation()}
+                      ref={imgRef}
                     />
                   </Zoom>
                 </div>

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
@@ -27,6 +27,7 @@ import { useMyData } from "@/api/users/getMe";
 import { isMobileState } from "@/states/isMobileState";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { FollowingFeedsResponse } from "@/api/feeds/getFeedsFollowing";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 interface FollowingFeedProps {
   id: string;
@@ -55,6 +56,9 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
   const [isContentTooLong, setIsContentTooLong] = useState(false);
   const contentRef = useRef<HTMLParagraphElement | null>(null);
   const isMobile = useRecoilValue(isMobileState);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
+  const divRef = usePreventRightClick<HTMLDivElement>();
+  const sectionRef = usePreventRightClick<HTMLElement>();
 
   useIsMobile();
   usePreventScroll(!!overlayImage);
@@ -220,6 +224,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   ) : (
                     <Image
@@ -231,6 +236,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                       quality={50}
                       style={{ objectFit: "cover" }}
                       unoptimized
+                      ref={imgRef}
                     />
                   )}
                 </Link>
@@ -277,9 +283,9 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                 <ShareBtn feedId={id} title={details.title} image={details.cards[0]} />
               </div>
             </section>
-            <section className={styles.imageGallery}>
+            <section className={styles.imageGallery} ref={sectionRef}>
               {details.cards.slice(0, 2).map((card, index) => (
-                <div key={index} className={styles.imageWrapper}>
+                <div key={index} className={styles.imageWrapper} ref={divRef}>
                   <img
                     src={card}
                     alt={`Card image ${index + 1}`}
@@ -288,6 +294,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                     className={styles.cardImage}
                     onClick={() => handleImageClick(card)}
                     loading="lazy"
+                    ref={imgRef}
                   />
                   {index === 1 && details.cards.length > 2 && !isExpanded && (
                     <>
@@ -302,23 +309,26 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                 </div>
               ))}
             </section>
-            {isExpanded &&
-              details.cards.slice(2).map((card, index) => (
-                <div key={index + 2} className={styles.imageWrapper2}>
-                  <img
-                    src={card}
-                    alt={`Card image ${index + 3}`}
-                    width={600}
-                    height={0}
-                    className={styles.cardImage}
-                    onClick={() => handleImageClick(card)}
-                    loading="lazy"
-                  />
-                </div>
-              ))}
+            <section ref={sectionRef}>
+              {isExpanded &&
+                details.cards.slice(2).map((card, index) => (
+                  <div key={index + 2} className={styles.imageWrapper2} ref={divRef}>
+                    <img
+                      src={card}
+                      alt={`Card image ${index + 3}`}
+                      width={600}
+                      height={0}
+                      className={styles.cardImage}
+                      onClick={() => handleImageClick(card)}
+                      loading="lazy"
+                      ref={imgRef}
+                    />
+                  </div>
+                ))}
+            </section>
             {overlayImage && (
               <div className={styles.overlay} onClick={() => setOverlayImage(null)}>
-                <div className={styles.overlayContent}>
+                <div className={styles.overlayContent} ref={divRef}>
                   <Zoom>
                     <img
                       src={overlayImage}
@@ -329,12 +339,13 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                       }}
                       onClick={(event) => event.stopPropagation()}
                       loading="lazy"
+                      ref={imgRef}
                     />
                   </Zoom>
                 </div>
               </div>
             )}
-            <section className={styles.contentContainer}>
+            <section className={styles.contentContainer} ref={sectionRef}>
               <h2 className={styles.title}>{details.title}</h2>
               <div className={styles.bar} />
               <p

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
@@ -295,6 +295,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                     onClick={() => handleImageClick(card)}
                     loading="lazy"
                     ref={imgRef}
+                    onContextMenu={(e) => e.preventDefault()}
                   />
                   {index === 1 && details.cards.length > 2 && !isExpanded && (
                     <>
@@ -322,6 +323,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                       onClick={() => handleImageClick(card)}
                       loading="lazy"
                       ref={imgRef}
+                      onContextMenu={(e) => e.preventDefault()}
                     />
                   </div>
                 ))}
@@ -340,6 +342,7 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
                       onClick={(event) => event.stopPropagation()}
                       loading="lazy"
                       ref={imgRef}
+                      onContextMenu={(e) => e.preventDefault()}
                     />
                   </Zoom>
                 </div>

--- a/src/components/FollowingPage/RecommendCard/RecommendCard.tsx
+++ b/src/components/FollowingPage/RecommendCard/RecommendCard.tsx
@@ -10,6 +10,7 @@ import { deleteFollow } from "@/api/users/deleteIdFollow";
 import IconComponent from "@/components/Asset/Icon";
 import { useRecoilValue } from "recoil";
 import { authState } from "@/states/authState";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function RecommendCard({
   id,
@@ -25,6 +26,8 @@ export default function RecommendCard({
   const { showToast } = useToast();
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
+  const divRef = usePreventRightClick<HTMLDivElement>();
 
   const handleFollowClick = async () => {
     try {
@@ -49,7 +52,7 @@ export default function RecommendCard({
   return (
     <div className={styles.container}>
       <Link href={`/${url}`}>
-        <div className={styles.imageWrapper}>
+        <div className={styles.imageWrapper} ref={divRef}>
           <div className={styles.imageContainer}>
             {thumbnails[0] ? (
               <div className={styles.background}>
@@ -66,6 +69,7 @@ export default function RecommendCard({
                     objectFit: "cover",
                     borderRadius: "12px 0 0 0",
                   }}
+                  ref={imgRef}
                 />
               </div>
             ) : (
@@ -83,6 +87,7 @@ export default function RecommendCard({
                     objectFit: "cover",
                     borderRadius: "12px 0 0 0",
                   }}
+                  ref={imgRef}
                 />
               </div>
             )}
@@ -103,6 +108,7 @@ export default function RecommendCard({
                     objectFit: "cover",
                     borderRadius: "0 12px 0 0",
                   }}
+                  ref={imgRef}
                 />
               </div>
             ) : (
@@ -120,6 +126,7 @@ export default function RecommendCard({
                     objectFit: "cover",
                     borderRadius: "0 12px 0 0",
                   }}
+                  ref={imgRef}
                 />
               </div>
             )}
@@ -138,6 +145,7 @@ export default function RecommendCard({
                 alt="인기 유저 프로필 이미지"
                 className={styles.profileImage}
                 unoptimized
+                ref={imgRef}
               />
             ) : (
               <Image
@@ -148,6 +156,7 @@ export default function RecommendCard({
                 alt="인기 유저 프로필 이미지"
                 className={styles.profileImage}
                 unoptimized
+                ref={imgRef}
               />
             )}
             <div className={styles.nameContainer}>

--- a/src/components/Layout/FollowNewFeed/FollowNewFeed.tsx
+++ b/src/components/Layout/FollowNewFeed/FollowNewFeed.tsx
@@ -14,6 +14,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
 import { Navigation } from "swiper/modules";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function FollowNewFeed() {
   const isMobile = useRecoilValue(isMobileState);
@@ -23,6 +24,7 @@ export default function FollowNewFeed() {
   useIsMobile();
   const { data, isLoading, refetch } = useFollowingNew({ size: 8 });
   const { pathname } = useRouter();
+  const divRef = usePreventRightClick<HTMLDivElement>();
 
   useEffect(() => {
     refetch();
@@ -43,7 +45,7 @@ export default function FollowNewFeed() {
   };
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} ref={divRef}>
       {data?.feeds?.length === 0 ? (
         <>
           <Title>팔로우하는 유저의 새 그림</Title>

--- a/src/components/Layout/ProfileCard/ProfileCard.tsx
+++ b/src/components/Layout/ProfileCard/ProfileCard.tsx
@@ -4,6 +4,7 @@ import { formatCurrency } from "@/utils/formatCurrency";
 import { ProfileCardProps } from "./ProfileCard.types";
 import Link from "next/link";
 import { formattedDate } from "@/utils/formatDate";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function ProfileCard({
   title,
@@ -16,6 +17,7 @@ export default function ProfileCard({
   viewCount,
 }: ProfileCardProps) {
   const hasMultipleImages = cards && cards.length > 1;
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   return (
     <div className={styles.container}>
@@ -26,7 +28,7 @@ export default function ProfileCard({
           </div>
         )}
         <Link href={`/feeds/${id}`}>
-          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} />
+          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} ref={imgRef} />
         </Link>
       </div>
       <div className={styles.infoContainer}>

--- a/src/components/Layout/RectangleCard/RectangleCard.tsx
+++ b/src/components/Layout/RectangleCard/RectangleCard.tsx
@@ -10,6 +10,7 @@ import { useRecoilValue } from "recoil";
 import { authState } from "@/states/authState";
 import { deleteLike, putLike } from "@/api/feeds/putDeleteFeedsLike";
 import { isMobileState, isTabletState } from "@/states/isMobileState";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function RectangleCard({
   id,
@@ -27,6 +28,7 @@ export default function RectangleCard({
   const isTablet = useRecoilValue(isTabletState);
   const [isLiked, setIsLiked] = useState(initialIsLike);
   const [likeCount, setLikeCount] = useState(initialLikeCount);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -51,7 +53,13 @@ export default function RectangleCard({
               </div>
             )}
             <Link href={`/feeds/${id}`}>
-              <img src={thumbnail} alt={title} loading="lazy" className={styles.image} />
+              <img
+                src={thumbnail}
+                alt={title}
+                loading="lazy"
+                className={styles.image}
+                ref={imgRef}
+              />
             </Link>
           </div>
           {!isTablet ? (
@@ -87,6 +95,7 @@ export default function RectangleCard({
                           quality={50}
                           className={styles.profileImage}
                           unoptimized
+                          ref={imgRef}
                         />
                       ) : (
                         <Image
@@ -97,6 +106,7 @@ export default function RectangleCard({
                           alt="프로필 이미지"
                           className={styles.profileImage}
                           unoptimized
+                          ref={imgRef}
                         />
                       )}
                       <p className={styles.author}>{author.name}</p>
@@ -122,6 +132,7 @@ export default function RectangleCard({
                         quality={50}
                         className={styles.profileImage}
                         unoptimized
+                        ref={imgRef}
                       />
                     ) : (
                       <Image
@@ -132,6 +143,7 @@ export default function RectangleCard({
                         alt="프로필 이미지"
                         className={styles.profileImage}
                         unoptimized
+                        ref={imgRef}
                       />
                     )}
                     <p className={styles.author}>{author.name}</p>

--- a/src/components/Layout/SquareCard/SquareCard.tsx
+++ b/src/components/Layout/SquareCard/SquareCard.tsx
@@ -3,6 +3,7 @@ import IconComponent from "@/components/Asset/Icon";
 import styles from "./SquareCard.module.scss";
 import { formatCurrency } from "@/utils/formatCurrency";
 import { SquareCardProps } from "./SquareCard.types";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import Link from "next/link";
 import { useRecoilValue } from "recoil";
 import { authState } from "@/states/authState";
@@ -25,6 +26,7 @@ export default function SquareCard({
   const [isLiked, setIsLiked] = useState(isLike);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
   const hasMultipleImages = cards && cards.length > 1;
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -52,7 +54,7 @@ export default function SquareCard({
           </div>
         )}
         <Link href={`/feeds/${id}`}>
-          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} />
+          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} ref={imgRef} />
         </Link>
       </div>
       <div className={styles.infoContainer}>

--- a/src/components/PopularPage/PopularFeed/FeedCard/FeedCard.tsx
+++ b/src/components/PopularPage/PopularFeed/FeedCard/FeedCard.tsx
@@ -7,6 +7,7 @@ import { useRecoilValue } from "recoil";
 import { authState } from "@/states/authState";
 import { deleteLike, putLike } from "@/api/feeds/putDeleteFeedsLike";
 import { FeedCardProps } from "./FeedCard.types";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function FeedCard({
   id,
@@ -20,6 +21,7 @@ export default function FeedCard({
   const { isLoggedIn } = useRecoilValue(authState);
   const [isLiked, setIsLiked] = useState(isLike);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -42,7 +44,7 @@ export default function FeedCard({
           </div>
         )}
         <Link href={`/feeds/${id}`}>
-          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} />
+          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} ref={imgRef} />
         </Link>
       </div>
       <div className={styles.infoContainer}>

--- a/src/components/PopularPage/PopularTag/Tag/Tag.tsx
+++ b/src/components/PopularPage/PopularTag/Tag/Tag.tsx
@@ -1,11 +1,20 @@
 import type { PopularTagResponse } from "@/api/tags/getTagsPopular";
 import styles from "./Tag.module.scss";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function Tag({ tagName, thumbnail }: PopularTagResponse) {
+  const imgRef = usePreventRightClick<HTMLImageElement>();
+  const divRef = usePreventRightClick<HTMLDivElement>();
   return (
     <div className={styles.container}>
-      <div className={styles.imageWrapper}>
-        <img src={thumbnail} alt="인기 태그 이미지" className={styles.image} loading="lazy" />
+      <div className={styles.imageWrapper} ref={divRef}>
+        <img
+          src={thumbnail}
+          alt="인기 태그 이미지"
+          className={styles.image}
+          loading="lazy"
+          ref={imgRef}
+        />
         <div className={styles.gradient} />
         <p className={styles.title}>{tagName}</p>
       </div>

--- a/src/components/PopularPage/PopularUser/PopularUser.tsx
+++ b/src/components/PopularPage/PopularUser/PopularUser.tsx
@@ -9,12 +9,14 @@ import { isMobileState, isTabletState } from "@/states/isMobileState";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import { authState } from "@/states/authState";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function PopularUser() {
   const { user_id } = useRecoilValue(authState);
   const { data, isLoading } = usePopular();
   const [randomUsers, setRandomUsers] = useState<PopularUserResponse[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
+  const divRef = usePreventRightClick<HTMLDivElement>();
   const isMobile = useRecoilValue(isMobileState);
   const isTablet = useRecoilValue(isTabletState);
 
@@ -56,7 +58,7 @@ export default function PopularUser() {
   if (isLoading) return <Loader />;
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} ref={divRef}>
       <Title>인기 유저</Title>
       {isMobile || isTablet ? (
         <Swiper

--- a/src/components/PopularPage/PopularUser/User/User.tsx
+++ b/src/components/PopularPage/PopularUser/User/User.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useToast } from "@/hooks/useToast";
 import { putFollow } from "@/api/users/putIdFollow";
 import { deleteFollow } from "@/api/users/deleteIdFollow";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function User({
   id,
@@ -20,6 +21,7 @@ export default function User({
   const { showToast } = useToast();
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   const handleFollowClick = async () => {
     try {
@@ -53,6 +55,7 @@ export default function User({
               loading="lazy"
               alt="인기 유저 헤더 이미지"
               className={styles.backgroundLeft}
+              ref={imgRef}
             />
           ) : (
             <img
@@ -62,6 +65,7 @@ export default function User({
               loading="lazy"
               alt="인기 유저 헤더 이미지"
               className={styles.backgroundLeft}
+              ref={imgRef}
             />
           )}
           {thumbnails[1] ? (
@@ -72,6 +76,7 @@ export default function User({
               loading="lazy"
               alt="인기 유저 헤더 이미지"
               className={styles.backgroundRight}
+              ref={imgRef}
             />
           ) : (
             <img
@@ -81,6 +86,7 @@ export default function User({
               loading="lazy"
               alt="인기 유저 헤더 이미지"
               className={styles.backgroundRight}
+              ref={imgRef}
             />
           )}
         </div>
@@ -97,6 +103,7 @@ export default function User({
                 alt="인기 유저 프로필 이미지"
                 className={styles.profileImage}
                 unoptimized
+                ref={imgRef}
               />
             ) : (
               <Image
@@ -107,6 +114,7 @@ export default function User({
                 alt="인기 유저 프로필 이미지"
                 className={styles.profileImage}
                 unoptimized
+                ref={imgRef}
               />
             )}
             <div className={styles.nameContainer}>

--- a/src/components/ProfilePage/Profile/Profile.tsx
+++ b/src/components/ProfilePage/Profile/Profile.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 import { formatCurrency } from "@/utils/formatCurrency";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { ProfileProps } from "./Profile.types";
-// import { useUserData } from "@/api/users/getId";
 import { useUserDataByUrl } from "@/api/users/getId";
 import { deleteFollow } from "@/api/users/deleteIdFollow";
 import { putFollow } from "@/api/users/putIdFollow";
@@ -24,18 +23,18 @@ import Dropdown from "@/components/Dropdown/Dropdown";
 import { isMobileState, isTabletState } from "@/states/isMobileState";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { deleteMe } from "@/api/users/deleteMe";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 export default function Profile({ isMyProfile, id, url }: ProfileProps) {
   const { isLoggedIn, user_id } = useRecoilValue(authState);
   const [, setAuth] = useRecoilState(authState);
   const [, setModal] = useRecoilState(modalState);
-  // TODO
   const { data: myData, refetch } = useMyData();
-  // const { data: userData, refetch: refetchUserData } = useUserData(id);
   const { data: userData, refetch: refetchUserData } = useUserDataByUrl(url);
   const [profileImage, setProfileImage] = useState<string>("");
   const [coverImage, setCoverImage] = useState<string>("");
   const { showToast } = useToast();
+  const imgRef = usePreventRightClick<HTMLImageElement>();
   const isMobile = useRecoilValue(isMobileState);
   const isTablet = useRecoilValue(isTabletState);
   useIsMobile();
@@ -349,6 +348,7 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
                   height: isMobile ? "240px" : isTablet ? "300px" : "400px",
                   objectFit: "cover",
                 }}
+                ref={imgRef}
               />
               {userData.id === user_id && (
                 <div className={styles.coverBtns}>
@@ -425,6 +425,7 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
                       alt="프로필 이미지"
                       className={styles.profileImage}
                       unoptimized
+                      ref={imgRef}
                     />
                   )}
                   {userData.id === user_id && (
@@ -455,6 +456,7 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
                     quality={75}
                     className={styles.profileImage}
                     unoptimized
+                    ref={imgRef}
                   />
                   {userData.id === user_id && (
                     <>

--- a/src/components/SearchPage/Feed/SearchCard/SearchCard.tsx
+++ b/src/components/SearchPage/Feed/SearchCard/SearchCard.tsx
@@ -8,6 +8,7 @@ import { authState } from "@/states/authState";
 import { deleteLike, putLike } from "@/api/feeds/putDeleteFeedsLike";
 import { SearchCardProps } from "./SearchCard.types";
 import { Swiper, SwiperSlide } from "swiper/react";
+import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import "swiper/css";
 
 export default function SearchCard({
@@ -24,6 +25,7 @@ export default function SearchCard({
   const { isLoggedIn } = useRecoilValue(authState);
   const [isLiked, setIsLiked] = useState(isLike);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
+  const imgRef = usePreventRightClick<HTMLImageElement>();
 
   const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -46,7 +48,7 @@ export default function SearchCard({
           </div>
         )}
         <Link href={`/feeds/${id}`}>
-          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} />
+          <img src={thumbnail} alt={title} loading="lazy" className={styles.image} ref={imgRef} />
         </Link>
       </div>
       {tags.length > 0 && (

--- a/src/hooks/usePreventRightClick.ts
+++ b/src/hooks/usePreventRightClick.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+import { useToast } from "@/hooks/useToast";
+
+export function usePreventRightClick<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const disableRightClick = (e: MouseEvent) => {
+      e.preventDefault();
+      showToast("우클릭이 차단되었습니다.", "information");
+    };
+
+    element.addEventListener("contextmenu", disableRightClick);
+
+    return () => {
+      element.removeEventListener("contextmenu", disableRightClick);
+    };
+  }, [showToast]);
+
+  return ref;
+}

--- a/src/hooks/usePreventRightClick.ts
+++ b/src/hooks/usePreventRightClick.ts
@@ -1,9 +1,7 @@
 import { useEffect, useRef } from "react";
-import { useToast } from "@/hooks/useToast";
 
 export function usePreventRightClick<T extends HTMLElement>() {
   const ref = useRef<T>(null);
-  const { showToast } = useToast();
 
   useEffect(() => {
     const element = ref.current;
@@ -11,7 +9,6 @@ export function usePreventRightClick<T extends HTMLElement>() {
 
     const disableRightClick = (e: MouseEvent) => {
       e.preventDefault();
-      showToast("우클릭이 차단되었습니다.", "information");
     };
 
     element.addEventListener("contextmenu", disableRightClick);
@@ -19,7 +16,7 @@ export function usePreventRightClick<T extends HTMLElement>() {
     return () => {
       element.removeEventListener("contextmenu", disableRightClick);
     };
-  }, [showToast]);
+  });
 
   return ref;
 }


### PR DESCRIPTION
### 🔎 작업 내용

> close #23

- [x] `usePreventRightClick` 훅 정의
  - [x] 우클릭 시 토스트가 뜨도록 변경
- [x] 피드나 프로필 이미지가 있는 태그들에 적용

### 📸 스크린샷


### :loudspeaker: 전달사항
토스트 말고 다른 방법 제안해주셔도 됩니다..!

