### PR TITLE
Fix: 헤더 스크롤 및 아이콘 버그 수정

### DIFF
--- a/src/components/Layout/Header/Header.module.scss
+++ b/src/components/Layout/Header/Header.module.scss
@@ -112,9 +112,7 @@
     position: absolute;
     height: 2px;
     background-color: $gray80;
-    transition:
-      transform 0.3s ease,
-      width 0.3s ease;
+    transition: transform 0.3s ease, width 0.3s ease;
     bottom: -8px;
   }
 }
@@ -244,9 +242,7 @@
   border-radius: 12px;
   border: 1px solid $gray30;
   background-color: $gray10;
-  transition:
-    transform 0.3s ease,
-    width 0.3s ease;
+  transition: transform 0.3s ease, width 0.3s ease;
 
   .input {
     width: 100%;

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -223,26 +223,6 @@ export default function Header() {
 
   usePreventScroll(isMenuOpen || (isMobile && showNotifications));
 
-  const handleSearchKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
-
-    if (e.key === "Enter") {
-      const trimmedKeyword = keyword.trim();
-      if (trimmedKeyword.length < 2) {
-        showToast("두 글자 이상 입력해주세요.", "warning");
-        return;
-      }
-      let tab = "feed";
-      if (router.pathname.includes("board")) {
-        tab = "board";
-      } else if (router.pathname.includes("posts")) {
-        tab = "board";
-      }
-      router.push(`/search?tab=${tab}&keyword=${encodeURIComponent(trimmedKeyword)}`);
-      setKeyword("");
-    }
-  };
-
   return (
     <header className={isUserPage ? styles.userPageHeader : styles.header}>
       <div className={styles.container}>
@@ -284,9 +264,13 @@ export default function Header() {
           )}
           <div className={styles.icons}>
             <Link href="/search">
-              <IconComponent name="search" size={24} padding={8} isBtn />
+              {!isUserPage ? (
+                <IconComponent name="search" size={24} padding={8} isBtn />
+              ) : (
+                <IconComponent name="searchWhite" size={24} padding={8} isBtn />
+              )}
             </Link>
-            {isLoggedIn && myData && (
+            {(!isMobile || !isTablet) && isLoggedIn && myData && (
               <div className={styles.notificationWrapper} ref={notificationRef}>
                 <div className={styles.notification} onClick={toggleNotifications}>
                   <IconComponent name={name} size={40} isBtn />
@@ -303,29 +287,16 @@ export default function Header() {
                     className={styles.profileContainer}
                     onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                   >
-                    {myData.image !== null ? (
-                      <Image
-                        src={myData.image}
-                        width={28}
-                        height={28}
-                        alt="프로필 이미지"
-                        className={styles.profileImage}
-                        quality={50}
-                        style={{ objectFit: "cover" }}
-                        unoptimized
-                      />
-                    ) : (
-                      <Image
-                        src="/image/default.svg"
-                        width={28}
-                        height={28}
-                        alt="프로필 이미지"
-                        className={styles.profileImage}
-                        quality={50}
-                        style={{ objectFit: "cover" }}
-                        unoptimized
-                      />
-                    )}
+                    <Image
+                      src={myData.image || "/image/default.svg"}
+                      width={28}
+                      height={28}
+                      alt="프로필 이미지"
+                      className={styles.profileImage}
+                      quality={50}
+                      style={{ objectFit: "cover" }}
+                      unoptimized
+                    />
                   </div>
                   {isDropdownOpen && (
                     <div className={styles.dropdown} ref={dropdownRef}>
@@ -337,29 +308,16 @@ export default function Header() {
                             window.scrollTo(0, 0);
                           }}
                         >
-                          {myData.image !== null ? (
-                            <Image
-                              src={myData.image}
-                              width={28}
-                              height={28}
-                              alt="프로필 이미지"
-                              className={styles.dropdownProfileImage}
-                              quality={50}
-                              style={{ objectFit: "cover" }}
-                              unoptimized
-                            />
-                          ) : (
-                            <Image
-                              src="/image/default.svg"
-                              width={28}
-                              height={28}
-                              alt="프로필 이미지"
-                              className={styles.dropdownProfileImage}
-                              quality={50}
-                              style={{ objectFit: "cover" }}
-                              unoptimized
-                            />
-                          )}
+                          <Image
+                            src={myData.image || "/image/default.svg"}
+                            width={28}
+                            height={28}
+                            alt="프로필 이미지"
+                            className={styles.dropdownProfileImage}
+                            quality={50}
+                            style={{ objectFit: "cover" }}
+                            unoptimized
+                          />
                           <span>내 프로필</span>
                         </div>
                       </Link>


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 로그인 상태에서 헤더 스크롤 해야 오른쪽 wrapper가 보이는 버그 
    => 초기 렌더링에도 보이도록 수정
- [x] 내 프로필 화면에서 검색 아이콘이 반대로 되어있는 버그 수정

### 📸 스크린샷
> 다음과 같은 두번째 버그를 수정했습니다.
- 스크롤 전
  <img width="320" alt="스크린샷 2025-04-14 오전 10 14 19" src="https://github.com/user-attachments/assets/41911db8-a6a2-480c-a071-5c1bfc132b55" />
- 스크롤 후
  <img width="320" alt="스크린샷 2025-04-14 오전 10 14 23" src="https://github.com/user-attachments/assets/17796ade-76f6-41fb-8932-f883a2b22b8f" />



### :loudspeaker: 전달사항
어차피 헤더 변경될 예정이라 대충만 수정했습니다..!~
- 추가한 라이브러리나 특이 사항
