### PR TITLE
Fix: 홈 화면에서만 커스텀 훅으로 인증 상태 동기화

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/useToast";
 import Notifications from "@/components/Notifications/Notifications";
 import { useDeviceStore } from "@/states/deviceStore";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import useAuthCheck from "@/hooks/useAuthCheck";
 import { usePreventScroll } from "@/hooks/usePreventScroll";
 import Dropdown from "@/components/Dropdown/Dropdown";
 import Contact from "./Contact/Contact";
@@ -49,6 +50,8 @@ export default function Header() {
   const hideBtn = ["/write", "/feeds/[id]/edit", "/board/write", "/posts/[id]/edit"].includes(
     router.pathname,
   );
+  const [isHome, setIsHome] = useState(false);
+  useAuthCheck(setIsHome);
   useIsMobile();
   const email = "grimity.official@gmail.com";
   const navItems = [

--- a/src/hooks/useAuthCheck.ts
+++ b/src/hooks/useAuthCheck.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/router";
+import { useAuthStore } from "@/states/authStore";
+
+export default function useAuthCheck(setIsHome: (home: boolean) => void) {
+  const router = useRouter();
+  const isAuth = useRef(false);
+
+  const { isLoggedIn, setIsLoggedIn, setAccessToken, setUserId } = useAuthStore();
+
+  useEffect(() => {
+    setIsHome(true);
+
+    if (isAuth.current || router.pathname !== "/") return;
+
+    const accessToken = localStorage.getItem("access_token");
+
+    if (accessToken) {
+      if (!isLoggedIn) {
+        setIsLoggedIn(true);
+        setAccessToken(accessToken);
+
+        const userId = localStorage.getItem("user_id");
+        if (userId) setUserId(userId);
+      }
+    } else {
+      if (isLoggedIn) {
+        setIsLoggedIn(false);
+        setAccessToken("");
+        setUserId("");
+      }
+    }
+
+    isAuth.current = true;
+  }, [router.pathname]);
+
+  // 라우터 이벤트 감지
+  useEffect(() => {
+    const handleRouteChange = () => {
+      isAuth.current = false;
+    };
+
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChange);
+    };
+  }, [router.events]);
+}


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 상태 관리와 인증 관련 문제 해결 (zustand 스토어와 로컬스토리지 동기화)
- [x] 홈 페이지(`/`)에서의 조건부 렌더링 문제 해결
  
### 📸 스크린샷

### :loudspeaker: 전달사항

앱을 처음 새로 고침할 때, 홈 화면의 경우 초기 / 페이지여서 서버측에서 먼저 불러오는데, 이때 하이드레이션이 되기 전에 렌더링이 발생할 수 있습니다. zustand 상태가 초기에는 비어 있는 상태이고, 이후 useEffect가 실행되어 조건부렌더링이 제대로 동작하지 않았던 것으로 추측됩니다..!