### PR TITLE
Fix: 커버 이미지 프로필 영역에서 완전히 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
-        "@grimity/dto": "^1.0.14",
+        "@grimity/dto": "^1.0.16",
         "@grimity/shared-types": "^1.3.0",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@grimity/dto": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@grimity/dto/-/dto-1.0.14.tgz",
-      "integrity": "sha512-wfjW8eUEWZkeoHFadduS23DucYvCoKVreGKeXKNnOPJARnVZIgrTq71ssfZfqOiXyWyi55UFUhkNqzgT/NSxHQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@grimity/dto/-/dto-1.0.16.tgz",
+      "integrity": "sha512-UzHO/sCtCwqNF0NXksi9KhhTWfO8ICBynLPVg01lsMjutEKlxsos3TtEUksOQe82wuWjDrFyAOqthAaX82OWSQ==",
       "dev": true
     },
     "node_modules/@grimity/shared-types": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
-    "@grimity/dto": "^1.0.14",
+    "@grimity/dto": "^1.0.16",
     "@grimity/shared-types": "^1.3.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/components/ProfilePage/Profile/Profile.module.scss
+++ b/src/components/ProfilePage/Profile/Profile.module.scss
@@ -9,16 +9,26 @@
   background-color: $gray0;
 
   .backgroundImage {
-    width: 100%;
+    width: calc(100vw - 258px);
+    height: 400px;
     position: absolute;
-    top: 0;
-    left: 0;
+    right: 0;
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    align-items: flex-end;
     justify-content: center;
     overflow-x: hidden;
     z-index: 2;
+
+    @include Size("tablet") {
+      width: calc(100vw - 81px);
+      height: 300px;
+    }
+
+    @include Size("mobile") {
+      height: 240px;
+      width: 100%;
+    }
   }
 
   .background {
@@ -30,24 +40,26 @@
     align-items: center;
     justify-content: center;
     position: relative;
-
-    @include Size("mobile") {
-      width: 100vw;
-      height: 240px;
-    }
   }
 
   .backgroundDefaultImageContainer {
-    position: absolute;
-    top: 60;
-    left: 258;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    width: auto;
+    width: calc(100vw - 258px);
     height: 200px;
-    overflow: hidden;
+    position: absolute;
+    right: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: center;
+    overflow-x: hidden;
+
+    @include Size("tablet") {
+      width: calc(100vw - 81px);
+    }
+
+    @include Size("mobile") {
+      width: 100%;
+    }
   }
 
   .backgroundDefaultImage {
@@ -58,8 +70,8 @@
 
   .backgroundAddMessage {
     position: absolute;
-    top: calc(50%);
-    left: calc(50%);
+    top: 50%;
+    left: 50%;
     transform: translate(-50%, -50%);
     display: flex;
     align-items: center;
@@ -70,20 +82,13 @@
     z-index: 2;
     padding: 16px 24px;
     border-radius: 8px;
-
-    @include Size("mobile") {
-      left: 50%;
-    }
-    @include Size("tablet") {
-      left: calc(50% + 36px);
-    }
   }
 
   .coverBtns {
     position: absolute;
     right: 16px;
     bottom: 16px;
-    z-index: 2;
+    z-index: 3;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -121,7 +126,7 @@
   }
 
   .infoContainer {
-    margin-top: 380px;
+    margin-top: 440px;
     width: 100%;
     display: flex;
     align-items: flex-start;
@@ -129,11 +134,11 @@
     z-index: 3;
 
     @include Size("mobile") {
-      margin-top: 140px;
+      margin-top: 200px;
     }
 
     @include Size("tablet") {
-      margin-top: 280px;
+      margin-top: 340px;
     }
   }
 

--- a/src/components/ProfilePage/Profile/Profile.module.scss
+++ b/src/components/ProfilePage/Profile/Profile.module.scss
@@ -9,7 +9,7 @@
   background-color: $gray0;
 
   .backgroundImage {
-    width: calc(100vw - 258px);
+    width: calc(100vw - 254px - 1px);
     height: 400px;
     position: absolute;
     right: 0;
@@ -21,7 +21,7 @@
     z-index: 2;
 
     @include Size("tablet") {
-      width: calc(100vw - 81px);
+      width: calc(100vw - 80px - 1px);
       height: 300px;
     }
 

--- a/src/components/ProfilePage/Profile/Profile.tsx
+++ b/src/components/ProfilePage/Profile/Profile.tsx
@@ -330,14 +330,12 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
             <div className={styles.backgroundImage}>
               <img
                 src={coverImage}
-                width={1400} // 임의 지정
-                height={isMobile ? 240 : isTablet ? 300 : 400}
                 alt="backgroundImage"
                 loading="lazy"
                 style={{
-                  width: "100vw",
-                  height: isMobile ? "240px" : isTablet ? "300px" : "400px",
                   objectFit: "cover",
+                  width: "100%",
+                  height: "100%",
                 }}
                 ref={imgRef}
               />

--- a/src/components/ProfilePage/ProfilePage.module.scss
+++ b/src/components/ProfilePage/ProfilePage.module.scss
@@ -11,6 +11,8 @@
   .center {
     max-width: 1280px;
     width: 100%;
+    margin-top: 60;
+    margin-left: 258;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 커버 이미지 프로필 영역에서 완전히 분리


### 📸 스크린샷

> 커버 없을때

<img width="787" alt="스크린샷 2025-04-30 오전 12 54 41" src="https://github.com/user-attachments/assets/3516089d-9da8-493a-9aee-183dbbabf3bf" />

> 커버 있을때 
<img width="799" alt="스크린샷 2025-04-30 오전 12 54 16" src="https://github.com/user-attachments/assets/a3935613-13c6-406f-aa9f-b550a8ab7954" />
<img width="584" alt="tablet" src="https://github.com/user-attachments/assets/6bffca5c-6187-4783-94dd-58b5a230b3ee" />
<img width="584" alt="스크린샷 2025-04-30 오전 12 54 05" src="https://github.com/user-attachments/assets/e26bf658-1aeb-4873-9d9f-9b659043febb" />



### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
  - dto 업데이트