### PR TITLE
게시글 상세페이지 하단 게시글 리팩터링

### DIFF
--- a/src/components/Board/BoardAll/BoardAll.tsx
+++ b/src/components/Board/BoardAll/BoardAll.tsx
@@ -76,7 +76,7 @@ export default function BoardAll({ isDetail, hasChip }: BoardAllProps) {
       }
     } else if (noticesData && latestData) {
       const mergedPosts =
-        currentPage === 1 ? [...noticesData, ...latestData.posts] : latestData.posts;
+        currentPage === 1 && !isDetail ? [...noticesData, ...latestData.posts] : latestData.posts;
 
       setPosts(mergedPosts);
       setTotalCount(latestData.totalCount + (currentPage === 1 ? noticesData.length : 0));

--- a/src/components/Board/BoardAll/BoardAll.tsx
+++ b/src/components/Board/BoardAll/BoardAll.tsx
@@ -34,11 +34,12 @@ export default function BoardAll({ isDetail, hasChip }: BoardAllProps) {
   const { query } = router;
   const currentType = (query.type as string) || "all";
   const currentPage = Number(query.page) || 1;
-  const totalPages = Math.ceil(totalCount / 10);
+  const totalPages = Math.ceil(totalCount / (isDetail ? 5 : 10));
   const { showToast } = useToast();
   const isMobile = useDeviceStore((state) => state.isMobile);
   useIsMobile();
   const { pathname } = useRouter();
+  const postsPerPage = isDetail ? 5 : 10;
 
   const { data: noticesData } = usePostsNotices();
   const {
@@ -48,14 +49,14 @@ export default function BoardAll({ isDetail, hasChip }: BoardAllProps) {
   } = usePostsLatest({
     type: currentType.toUpperCase() as "ALL" | "QUESTION" | "FEEDBACK",
     page: currentPage,
-    size: 10,
+    size: postsPerPage,
   });
 
   const { data: searchData, isLoading: isSearchLoading } = usePostSearch(
     query.keyword
       ? {
           searchBy: (query.searchBy as "combined" | "name") || "combined",
-          size: 10,
+          size: postsPerPage,
           page: currentPage,
           keyword: query.keyword as string,
         }

--- a/src/components/Board/BoardAll/BoardAll.tsx
+++ b/src/components/Board/BoardAll/BoardAll.tsx
@@ -183,7 +183,7 @@ export default function BoardAll({ isDetail, hasChip }: BoardAllProps) {
 
   return (
     <div className={styles.container}>
-      {isMobile && currentType === "all" && (
+      {isMobile && currentType === "all" && !isDetail && (
         <div className={styles.search}>
           <div className={styles.dropdown}>
             <Dropdown


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 게시글 상세페이지 모바일 뷰에서 검색바 삭제
- [x] 게시글 상세페이지에선 공지글 안보여주기
- [x] 게시글 상세페이지에선 하단 최신글 5개씩만 보여주기

### 📸 스크린샷

- 모바일 뷰
![image](https://github.com/user-attachments/assets/1333a63f-2662-4ec0-bf46-b782d7ab7f2c)

![image](https://github.com/user-attachments/assets/a5cd75df-37d9-41c0-b770-bdfd8a3628eb)

- PC 뷰
![image](https://github.com/user-attachments/assets/c4ed4bcf-9eef-4991-8aab-5476c0c33903)

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
