### PR TITLE
Refactor: main layout max-width 지정

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -6,19 +6,16 @@ import styles from "./Sidebar.module.scss";
 import { MENU_ITEMS } from "@/constants/menu";
 import { FOOTER_ITEMS } from "@/constants/footer";
 import { useAuthStore } from "@/states/authStore";
-import { useMyData } from "@/api/users/getMe";
 import { useDeviceStore } from "@/states/deviceStore";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useToast } from "@/hooks/useToast";
 
 const Sidebar = () => {
-  const [activeIndex, setActiveIndex] = useState(0);
   const [isAskDropdownOpen, setIsAskDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { showToast } = useToast();
   const email = "grimity.official@gmail.com";
   const { isLoggedIn } = useAuthStore((state) => state);
-  const { data: myData } = useMyData();
   const router = useRouter();
   const { isMobile } = useDeviceStore((state) => state);
   useIsMobile();
@@ -29,9 +26,8 @@ const Sidebar = () => {
 
   const footerItems = FOOTER_ITEMS;
 
-  const handleItemClick = (index: number, route: string) => {
-    setActiveIndex(index);
-    router.push(`${route}`);
+  const handleItemClick = (route: string) => {
+    router.push(`/${route}`);
   };
 
   const handleFooterClick = (itemIcon: FooterIconName, route?: string) => {
@@ -50,6 +46,17 @@ const Sidebar = () => {
       console.error("클립보드 복사 실패:", error);
       showToast("복사에 실패했습니다.", "success");
     }
+  };
+
+  const isItemActive = (route: string) => {
+    const currentPath = router.pathname;
+    
+    if (route === "/" && currentPath === "/") return true;
+    if (route === "popular" && currentPath === "/popular") return true;
+    if (route === "board" && (currentPath === "/board" || currentPath.startsWith("/posts/"))) return true;
+    if (route === "following" && currentPath === "/following") return true;
+    
+    return false;
   };
 
   useEffect(() => {
@@ -75,8 +82,8 @@ const Sidebar = () => {
                 key={index}
                 icon={item.icon as BaseIconName}
                 label={item.label}
-                onClick={() => handleItemClick(index, item.route)}
-                isActive={activeIndex === index}
+                onClick={() => handleItemClick(item.route)}
+                isActive={isItemActive(item.route)}
               />
             ))}
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import Ranking from "@/components/Layout/Ranking/Ranking";
 import NewFeed from "@/components/Layout/NewFeed/NewFeed";
-import { useAuthStore } from "@/states/authStore";
 import MainBoard from "@/components/Layout/MainBoard/MainBoard";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -19,10 +18,8 @@ export default function Home() {
   const router = useRouter();
   const [OGTitle] = useState("그리미티");
   const [OGUrl, setOGUrl] = useState(serviceUrl);
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const { restoreScrollPosition } = useScrollRestoration("home-scroll");
   const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
   useIsMobile();
 
   useEffect(() => {
@@ -40,20 +37,7 @@ export default function Home() {
     <>
       <InitialPageMeta title={OGTitle} url={OGUrl} />
       <div className={styles.container}>
-        {!isMobile && (
-          <>
-            <section className={styles.FeedSection}>
-              <Banner />
-              <Ranking />
-              <section className={styles.BoardSection}>
-                <MainBoard type="ALL" />
-                <MainBoard type="NOTICE" />
-              </section>
-              <NewFeed />
-            </section>
-          </>
-        )}
-        {isMobile && (
+        {isMobile ? (
           <>
             <section className={styles.MobileSection}>
               <Banner />
@@ -69,6 +53,16 @@ export default function Home() {
               </div>
             </Link>
           </>
+        ) : (
+          <section className={styles.FeedSection}>
+            <Banner />
+            <Ranking />
+            <section className={styles.BoardSection}>
+              <MainBoard type="ALL" />
+              <MainBoard type="NOTICE" />
+            </section>
+            <NewFeed />
+          </section>
         )}
       </div>
     </>

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -3,6 +3,8 @@
 
 .container {
   width: 100%;
+  max-width: 1462px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
### 🔎 작업 내용
- [x] main layout max-width 지정
- [x] Sidebar active 메뉴 오류 해결

### 📸 스크린샷

`2560*1440 해상도 수정 전후`

![image](https://github.com/user-attachments/assets/9521370f-a530-4730-ac5f-7ba0e62738b8)
![image](https://github.com/user-attachments/assets/304f7b95-cd91-431c-9d14-401d5049af46)
---

`Sidebar`
![image](https://github.com/user-attachments/assets/8b15078e-b22f-4b74-a9c1-9128daa211ef)
![image](https://github.com/user-attachments/assets/f6b48eb7-05d5-4188-9523-247e4b534def)

### :loudspeaker: 전달사항
Sidebar는 자유게시판 갔다가 로고 누르면 자유게시판 메뉴 active가 유지되는 오류 해결했습니다.
그리고 게시글 화면에서는 자유게시판 메뉴가 active 되어 보이는 게 자연스러울 거 같아서 추가했습니다!