### PR TITLE
refactor: #69 앨범 기능 추가 리팩토링

### DIFF
--- a/src/components/Modal/AlbumEdit/AlbumEdit.module.scss
+++ b/src/components/Modal/AlbumEdit/AlbumEdit.module.scss
@@ -1,4 +1,5 @@
 @use "@/styles/globals.scss" as *;
+@use "sass:color";
 
 .container {
   display: flex;
@@ -238,8 +239,14 @@
           @include Label2;
           gap: 8px;
 
-          &:focus-within {
+          &:focus {
             border: 1px solid $gray80;
+            outline: none;
+          }
+
+          &.editing {
+            border: 1px solid $gray80;
+            background-color: $gray0;
           }
 
           @include Size("mobile") {
@@ -315,15 +322,20 @@
   background-color: $gray10;
   border: 1px solid $gray30;
   position: relative;
-  overflow-y: auto;
   width: 100%;
   height: 52px;
   padding: 16px 20px;
   @include Label2;
   color: $gray80;
 
-  &:focus-within {
+  outline: none;
+
+  &:focus {
     border: 1px solid $secandary1;
     background-color: $gray0;
+  }
+
+  &:active {
+    background-color: color.adjust($gray0, $lightness: 8%);
   }
 }

--- a/src/components/Modal/AlbumEdit/AlbumEdit.tsx
+++ b/src/components/Modal/AlbumEdit/AlbumEdit.tsx
@@ -230,7 +230,9 @@ export default function AlbumEdit() {
                           <input
                             type="text"
                             value={inputValues[album.id] ?? ""}
-                            className={styles.albumItem}
+                            className={`${styles.albumItem} ${
+                              editingId === album.id ? styles.editing : ""
+                            }`}
                             disabled={editingId !== album.id}
                             onChange={(e) =>
                               setInputValues((prev) => ({
@@ -277,7 +279,7 @@ export default function AlbumEdit() {
                             className={styles.removeAlbumButton}
                             onClick={() => handleDeleteAlbum(album.id)}
                           >
-                            <IconComponent name="deleteAlbum" size={24} />
+                            <IconComponent name="deleteAlbum" size={24} isBtn />
                           </div>
                         )}
                       </div>
@@ -313,7 +315,7 @@ export default function AlbumEdit() {
                                   />
                                 </div>
                                 <div className={styles.removeAlbumButton}>
-                                  <IconComponent name="editOrder" />
+                                  <IconComponent name="editOrder" isBtn />
                                 </div>
                               </div>
                             )}

--- a/src/components/Modal/AlbumMove/AlbumMove.tsx
+++ b/src/components/Modal/AlbumMove/AlbumMove.tsx
@@ -97,7 +97,7 @@ export default function AlbumMove() {
             >
               전체 앨범
               <div className={styles.checkIcon}></div>
-              {selectedId === null && <IconComponent name="checkAlbum" size={14} />}
+              {selectedId === null && <IconComponent name="checkAlbum" size={14} isBtn />}
             </div>
             {albums.map((album) => (
               <div key={album.id}>
@@ -109,7 +109,7 @@ export default function AlbumMove() {
                 >
                   {album.name}
                   <div className={styles.checkIcon}></div>
-                  {selectedId === album.id && <IconComponent name="checkAlbum" size={14} />}
+                  {selectedId === album.id && <IconComponent name="checkAlbum" size={14} isBtn />}
                 </div>
               </div>
             ))}

--- a/src/components/Modal/AlbumSelect/AlbumSelect.tsx
+++ b/src/components/Modal/AlbumSelect/AlbumSelect.tsx
@@ -55,7 +55,7 @@ export default function AlbumSelect() {
                 >
                   {album.name}
                   <div className={styles.checkIcon}></div>
-                  {selectedId === album.id && <IconComponent name="checkAlbum" size={14} />}
+                  {selectedId === album.id && <IconComponent name="checkAlbum" size={14} isBtn />}
                 </div>
               </div>
             ))}

--- a/src/components/Upload/EditFeeds/EditFeeds.module.scss
+++ b/src/components/Upload/EditFeeds/EditFeeds.module.scss
@@ -324,6 +324,22 @@
                 align-items: center;
                 gap: 16px;
 
+                .albumClick {
+                  cursor: pointer;
+                  width: fit-content;
+                  display: flex;
+                  align-items: center;
+                }
+
+                .text {
+                  color: $gray50;
+                  @include Body1;
+
+                  &:selected {
+                    color: $gray70;
+                  }
+                }
+
                 .input {
                   width: 100%;
                   @include Body1;
@@ -344,6 +360,7 @@
               display: flex;
               flex-wrap: wrap;
               gap: 8px;
+              margin-bottom: 20px;
 
               .deleteTag {
                 height: 100%;
@@ -387,4 +404,12 @@
       }
     }
   }
+}
+
+.text {
+  color: $gray50;
+}
+
+.textSelected {
+  color: $gray70;
 }

--- a/src/components/Upload/EditFeeds/EditFeeds.tsx
+++ b/src/components/Upload/EditFeeds/EditFeeds.tsx
@@ -50,7 +50,7 @@ export default function EditFeeds({ id }: EditFeedsProps) {
       selectedAlbumId: selectedAlbumId,
       onSelect: (id: string, name: string) => {
         setSelectedAlbumId(id);
-        setSelectedAlbumName(name);
+        setSelectedAlbumName(id ? name : "");
       },
     };
 
@@ -670,9 +670,25 @@ export default function EditFeeds({ id }: EditFeedsProps) {
               <div className={styles.tagContainer}>
                 <div className={styles.tagInputContainer}>
                   <label className={styles.label}>앨범</label>
-                  <div className={styles.inputContainer} onClick={handleOpenAlbumSelect}>
-                    <div className={styles.text}>{selectedAlbumName || "앨범 선택"}</div>
-                    <IconComponent name="openAlbumSelect" size={14} isBtn />
+                  <div className={styles.inputContainer}>
+                    <div
+                      className={`${selectedAlbumName ? styles.textSelected : styles.text} ${
+                        styles.albumClick
+                      }`}
+                      onClick={handleOpenAlbumSelect}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      {selectedAlbumName || "앨범 선택"}
+                    </div>
+                    <div
+                      className={styles.albumClick}
+                      onClick={handleOpenAlbumSelect}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <IconComponent name="openAlbumSelect" size={14} isBtn />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/Upload/Upload.module.scss
+++ b/src/components/Upload/Upload.module.scss
@@ -337,69 +337,79 @@
                 align-items: center;
                 gap: 16px;
 
-                .text {
-                  color: $gray70;
-                  @include Body1;
+                .albumClick {
+                  cursor: pointer;
+                  width: fit-content;
                 }
 
-                .input {
-                  width: 100%;
+                .text {
+                  color: $gray50;
                   @include Body1;
-                  color: $gray80;
-                  border: none;
-                  outline: none;
-                  padding: 0;
 
-                  &::placeholder {
-                    color: $gray50;
+                  &:selected {
+                    color: $gray70;
                   }
                 }
               }
-            }
 
-            .tagList {
-              width: 100%;
-              display: flex;
-              flex-wrap: wrap;
-              gap: 8px;
+              .input {
+                width: 100%;
+                @include Body1;
+                color: $gray80;
+                border: none;
+                outline: none;
+                padding: 0;
 
-              .deleteTag {
-                height: 100%;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                cursor: pointer;
+                &::placeholder {
+                  color: $gray50;
+                }
               }
             }
           }
+
+          .tagList {
+            width: 100%;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-bottom: 20px;
+
+            .deleteTag {
+              height: 100%;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              cursor: pointer;
+            }
+          }
+        }
+      }
+
+      .optionContainer {
+        display: flex;
+        align-items: center;
+        gap: 36px;
+        margin-top: 50px;
+        @include Drag;
+
+        @include Size("mobile") {
+          margin-top: 28px;
+          flex-direction: column;
+          gap: 12px;
+          align-items: flex-start;
         }
 
-        .optionContainer {
+        .options {
           display: flex;
           align-items: center;
-          gap: 36px;
-          margin-top: 50px;
-          @include Drag;
+          gap: 20px;
+          @include Body1;
+          color: $gray70;
 
-          @include Size("mobile") {
-            margin-top: 28px;
-            flex-direction: column;
-            gap: 12px;
-            align-items: flex-start;
-          }
-
-          .options {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            @include Body1;
-            color: $gray70;
-
-            .option {
-              cursor: pointer;
-              transition: opacity 0.3s ease-in-out;
-              line-height: 0;
-            }
+          .option {
+            cursor: pointer;
+            transition: opacity 0.3s ease-in-out;
+            line-height: 0;
           }
         }
       }

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -42,7 +42,7 @@ export default function Upload() {
       selectedAlbumId: selectedAlbumId,
       onSelect: (id: string, name: string) => {
         setSelectedAlbumId(id);
-        setSelectedAlbumName(name);
+        setSelectedAlbumName(id ? name : "");
       },
     };
 
@@ -642,9 +642,18 @@ export default function Upload() {
               <div className={styles.tagContainer}>
                 <div className={styles.tagInputContainer}>
                   <label className={styles.label}>앨범</label>
-                  <div className={styles.inputContainer} onClick={handleOpenAlbumSelect}>
-                    <div className={styles.text}>{selectedAlbumName || "앨범 선택"}</div>
-                    <IconComponent name="openAlbumSelect" size={14} isBtn />
+                  <div className={styles.inputContainer}>
+                    <div
+                      className={`${
+                        selectedAlbumName?.trim() ? styles.textSelected : styles.text
+                      } ${styles.albumClick}`}
+                      onClick={handleOpenAlbumSelect}
+                    >
+                      {selectedAlbumName?.trim() || "앨범 선택"}
+                    </div>
+                    <div className={styles.albumClick} onClick={handleOpenAlbumSelect}>
+                      <IconComponent name="openAlbumSelect" size={14} isBtn />
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### 🔎 작업 내용
> Close #69 
- 앨범 편집 모달
  - [x] IconComponent에 IsBtn 추가
  - [x] input 요소 outline: none과 focus, active 상태의 border 지정
- 업로드/그림편집 페이지
  - [x] fit-content 및 커서 포인터 적용
  - [x] 글자 색 변경

### 📸 스크린샷
- 앨범 편집
  <img width="484" alt="image" src="https://github.com/user-attachments/assets/f21a2e3b-878b-493b-ab8e-fe134a54f234" />
  <img width="484" alt="image" src="https://github.com/user-attachments/assets/3c700a48-87ba-4483-9548-68b977507829" />

- 앨범 선택 
  <img width="484" alt="스크린샷 2025-05-17 오후 5 00 37" src="https://github.com/user-attachments/assets/0913a610-1115-40ad-8caf-f7d6f0f49e89" />
  <img width="484" alt="image" src="https://github.com/user-attachments/assets/379b18c9-a620-4d45-87ec-785471677ad8" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
