### PR TITLE
rename: 메인페이지 자유게시판 타이틀 변경

### DIFF
--- a/src/components/Layout/MainBoard/MainBoard.tsx
+++ b/src/components/Layout/MainBoard/MainBoard.tsx
@@ -40,7 +40,7 @@ export default function MainBoard({ type }: MainBoardProps) {
       case "NOTICE":
         return "공지사항";
       case "ALL":
-        return "최신 글 보기";
+        return "자유게시판 최신 글";
       default:
         return "";
     }

--- a/src/components/Layout/Title/Title.module.scss
+++ b/src/components/Layout/Title/Title.module.scss
@@ -17,7 +17,7 @@
   }
 
   .title {
-    @include Title4;
+    @include Title3;
     color: $gray80;
 
     @include Size("mobile") {
@@ -25,7 +25,7 @@
     }
 
     @include Size("tablet") {
-      @include Sub1;
+      @include Title3;
     }
   }
 

--- a/src/components/Layout/Title/Title.module.scss
+++ b/src/components/Layout/Title/Title.module.scss
@@ -21,7 +21,7 @@
     color: $gray80;
 
     @include Size("mobile") {
-      @include Sub2;
+      @include Sub1;
     }
 
     @include Size("tablet") {


### PR DESCRIPTION
### 🔎 작업 내용

> Close #55 

- [x] 메인 화면에서 보이는 타이틀 변경 (최신 글 보기 -> 자유게시판 최신 글)
 
### 📸 스크린샷

<img width="466" alt="image" src="https://github.com/user-attachments/assets/3cf99621-a405-4c7b-9a59-45bfe35e347a" />


### :loudspeaker: 전달사항

디자이너님이 기존 PC, 태블릿과 모바일 시안이 다른 부분을 전부 통일해주셨습니다!
따라서 타이틀만 변경했습니다..
