### PR TITLE
refactor: #83 상세 그림 및 팔로잉 피드 너비 제한

### DIFF
--- a/src/components/Detail/Detail.module.scss
+++ b/src/components/Detail/Detail.module.scss
@@ -9,6 +9,10 @@
   position: relative;
   padding-top: 30px;
 
+  @include Size("tablet") {
+    max-width: 480px;
+  }
+
   @include Size("mobile") {
     padding-top: 16px;
   }

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.module.scss
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.module.scss
@@ -7,7 +7,11 @@
   display: flex;
   justify-content: center;
   position: relative;
-  padding-top: 20px;
+  padding-top: 30px;
+
+  @include Size("tablet") {
+    max-width: 480px;
+  }
 
   @include Size("mobile") {
     padding-top: 16px;

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -23,7 +23,7 @@
     max-width: 1462px;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     margin: 60px auto 80px;
     padding: 0 30px;
 


### PR DESCRIPTION
### 🔎 작업 내용

> Close #83 

- Detail(상세 페이지), FollowingFeed(팔로잉하는 피드 페이지) 수정
  - [x] 태블릿 사이즈일 때`max-width: 480px` 제한


### 📸 스크린샷
<img width="409" alt="스크린샷 2025-05-25 오후 8 06 59" src="https://github.com/user-attachments/assets/2b098401-39ee-4e09-b767-0eaa76fcadb9" />

### :loudspeaker: 전달사항

