### PR TITLE
fix: 사이드바 home 라우팅 이중 슬래시 제거

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = () => {
   const isItemActive = (route: string) => {
     const currentPath = router.pathname;
 
-    if (route === "/" && currentPath === "/") return true;
+    if (route === "" && currentPath === "/") return true;
     if (route === "popular" && currentPath === "/popular") return true;
     if (route === "board" && (currentPath === "/board" || currentPath.startsWith("/posts/")))
       return true;

--- a/src/constants/menu.tsx
+++ b/src/constants/menu.tsx
@@ -6,7 +6,7 @@ export interface MenuItem {
   route: string;
 }
 
-export const MENU_ITEMS = [
+export const MENU_ITEMS: MenuItem[] = [
   { icon: "home", label: "홈", route: "" },
   { icon: "popular", label: "인기\n그림", route: "popular" },
   { icon: "board", label: "자유\n게시판", route: "board" },

--- a/src/constants/menu.tsx
+++ b/src/constants/menu.tsx
@@ -6,8 +6,8 @@ export interface MenuItem {
   route: string;
 }
 
-export const MENU_ITEMS: MenuItem[] = [
-  { icon: "home", label: "홈", route: "/" },
+export const MENU_ITEMS = [
+  { icon: "home", label: "홈", route: "" },
   { icon: "popular", label: "인기\n그림", route: "popular" },
   { icon: "board", label: "자유\n게시판", route: "board" },
 ];


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 사이드바 홈 메뉴아이템 `/`를 `""`로 변경

### 📸 스크린샷
> 현재 홈 경로(`/`)일때 `/${route}`를 통해 이동하면 `//`가 되어 다음 콘솔 에러가 발생하여 수정했습니다!
<img width="326" alt="스크린샷 2025-05-25 오후 8 15 17" src="https://github.com/user-attachments/assets/d9949dc5-8e5f-428f-ad83-1ec0481cbba8" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
