### PR TITLE
[Fix] 자유게시판 > 상세 - 작성자 프로필 진입 가능하도록 수정 및 코드 리팩토링

### DIFF
--- a/src/components/Board/Detail/Detail.tsx
+++ b/src/components/Board/Detail/Detail.tsx
@@ -1,28 +1,36 @@
-import { useRouter } from "next/router";
-import styles from "@/components/Board/Detail/Detail.module.scss";
-import { usePostsDetails } from "@/api/posts/getPostsId";
-import Loader from "@/components/Layout/Loader/Loader";
-import { timeAgo } from "@/utils/timeAgo";
-import DOMPurify from "dompurify";
-import Chip from "@/components/Chip/Chip";
-import { getTypeLabel } from "@/components/Board/BoardAll/AllCard/AllCard";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState, useCallback, useMemo } from "react";
+
+import DOMPurify from "dompurify";
+
+import Loader from "@/components/Layout/Loader/Loader";
+import Chip from "@/components/Chip/Chip";
 import Button from "@/components/Button/Button";
 import IconComponent from "@/components/Asset/Icon";
-import { useModalStore } from "@/states/modalStore";
-import { useToast } from "@/hooks/useToast";
-import { useAuthStore } from "@/states/authStore";
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { deletePostsSave, putPostsSave } from "@/api/posts/putDeletePostsIdSave";
-import { deletePostsLike, putPostsLike } from "@/api/posts/putDeletePostsLike";
-import { PostDetailProps } from "@/components/Board/Detail/Detail.types";
 import Dropdown from "@/components/Dropdown/Dropdown";
-import { deletePostsFeeds } from "@/api/posts/deletePostsId";
 import BoardAll from "@/components/Board/BoardAll/BoardAll";
 import ShareBtn from "@/components/Board/Detail/ShareBtn/ShareBtn";
 import PostComment from "@/components/Board/Detail/Comment/Comment";
-import { useDeviceStore } from "@/states/deviceStore";
+
+import { useToast } from "@/hooks/useToast";
 import { useIsMobile } from "@/hooks/useIsMobile";
+
+import { useModalStore } from "@/states/modalStore";
+import { useAuthStore } from "@/states/authStore";
+import { useDeviceStore } from "@/states/deviceStore";
+
+import { usePostsDetails } from "@/api/posts/getPostsId";
+import { deletePostsSave, putPostsSave } from "@/api/posts/putDeletePostsIdSave";
+import { deletePostsLike, putPostsLike } from "@/api/posts/putDeletePostsLike";
+import { deletePostsFeeds } from "@/api/posts/deletePostsId";
+
+import { timeAgo } from "@/utils/timeAgo";
+import { getTypeLabel } from "@/components/Board/BoardAll/AllCard/AllCard";
+
+import { PostDetailProps } from "@/components/Board/Detail/Detail.types";
+
+import styles from "@/components/Board/Detail/Detail.module.scss";
 
 export default function PostDetail({ id }: PostDetailProps) {
   const router = useRouter();


### PR DESCRIPTION
### 이슈
- 자유게시판 상세에서 작성자의 프로필을 접근할 수 없습니다.

### 변경 전
- 작성자 이름에 p 태그로 감싸져 있습니다.

### 🔎 작업 내용
- [x] Fix: 자유게시판 상세 페이지에서 작성자 프로필에 접근할 수 있도록 `Link` 태그를 추가했습니다.
- [x] Refector: 자유게시판 상세 코드에 조건이 많아 조건식을 분리했습니다.
- [x] Style: 자유게시판 상세 코드에 import의 구조를 정리했습니다.

### 📸 영상
https://github.com/user-attachments/assets/703a2c65-9a5d-41dc-b5b7-4c6f5e2889bd
