### PR TITLE
[Design] Datepicker 간격 조정

### DIFF
--- a/src/components/DatePicker/DatePicker.module.scss
+++ b/src/components/DatePicker/DatePicker.module.scss
@@ -34,7 +34,10 @@
 .dateContainer {
   display: flex;
   align-items: center;
-  gap: 10px;
+
+  @include Size("mobile") {
+    gap: 10px;
+  }
 }
 
 .calendarIcon {


### PR DESCRIPTION
### 🔎 작업 내용
- [x] 모바일에만 캘린더 아이콘이 있어서 gap: 10을 줬었는데, 데스크탑에는 불필요해서 해당 간격은 모바일에서만 적용되도록 수정했습니다.

### 📸 스크린샷
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/34998318-820c-4d14-8d6e-e5afd78d3c8f" />
