### PR TITLE
[Fix] 인증 로직 리팩토링 및 AuthLayout 구현

### DIFF
--- a/src/api/feeds/getFeedsFollowing.ts
+++ b/src/api/feeds/getFeedsFollowing.ts
@@ -1,6 +1,5 @@
 import axiosInstance from "@/constants/baseurl";
-import { useAuthStore } from "@/states/authStore";
-import { useInfiniteQuery, useQuery } from "react-query";
+import { useInfiniteQuery } from "react-query";
 import type { FollowingFeedsResponse } from "@grimity/dto";
 export type { FollowingFeedsResponse };
 
@@ -23,29 +22,12 @@ export async function getFollowingFeeds({
   }
 }
 
-export function useFollowingNew(params: FollowingFeedsRequest) {
-  return useQuery<FollowingFeedsResponse>(
-    ["FollowingFeedsNew", params.cursor, params.size],
-    () => getFollowingFeeds(params),
-    {
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
-      staleTime: 5 * 60 * 1000,
-      cacheTime: 10 * 60 * 1000,
-    },
-  );
-}
-
-export function useFollowingFeeds(params: FollowingFeedsRequest | null) {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const accessToken = typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
-
+export function useFollowingFeeds(params: FollowingFeedsRequest | null, enabled?: boolean) {
   return useInfiniteQuery<FollowingFeedsResponse>(
-    ["FollowingFeeds", params?.size],
+    ["FollowingFeeds", params],
     ({ pageParam = undefined }) => getFollowingFeeds({ ...params, cursor: pageParam }),
     {
-      enabled: !!params && isLoggedIn && Boolean(accessToken),
+      enabled,
       getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
       refetchOnMount: false,
       refetchOnReconnect: false,

--- a/src/components/Board/BoardWrite/BoardWrite.tsx
+++ b/src/components/Board/BoardWrite/BoardWrite.tsx
@@ -1,20 +1,26 @@
 import React, { useState, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
 import Script from "next/script";
-import Button from "@/components/Button/Button";
-import { postPresignedUrl } from "@/api/aws/postPresigned";
-import TextField from "@/components/TextField/TextField";
-import { useMutation } from "react-query";
-import { CreatePostRequest, PostsResponse, postPosts } from "@/api/posts/postPosts";
-import { AxiosError } from "axios";
 import { useRouter } from "next/router";
-import { useToast } from "@/hooks/useToast";
-import Loader from "@/components/Layout/Loader/Loader";
+
+import { useMutation } from "react-query";
+import { AxiosError } from "axios";
+
+import { postPresignedUrl } from "@/api/aws/postPresigned";
+import { CreatePostRequest, PostsResponse, postPosts } from "@/api/posts/postPosts";
+
 import { useDeviceStore } from "@/states/deviceStore";
+
+import Button from "@/components/Button/Button";
+import TextField from "@/components/TextField/TextField";
+import Loader from "@/components/Layout/Loader/Loader";
+
+import { useToast } from "@/hooks/useToast";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { useAuthStore } from "@/states/authStore";
-import styles from "@/components/Board/BoardWrite/BoardWrite.module.scss";
+
 import { imageUrl } from "@/constants/imageUrl";
+
+import styles from "@/components/Board/BoardWrite/BoardWrite.module.scss";
 
 const Editor = dynamic(() => import("@tinymce/tinymce-react").then((mod) => mod.Editor), {
   ssr: false,
@@ -22,10 +28,9 @@ const Editor = dynamic(() => import("@tinymce/tinymce-react").then((mod) => mod.
 });
 
 export default function BoardWrite() {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
   useIsMobile();
+
   const [title, setTitle] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("일반");
   const [content, setContent] = useState("");
@@ -39,13 +44,6 @@ export default function BoardWrite() {
       setIsScriptLoaded(true);
     }
   }, []);
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      showToast("로그인 후 작성 가능합니다.", "warning");
-      router.push("/");
-    }
-  }, [isLoggedIn, router]);
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);

--- a/src/components/Layout/AuthLayout/AuthLayout.tsx
+++ b/src/components/Layout/AuthLayout/AuthLayout.tsx
@@ -1,0 +1,29 @@
+import { useEffect, PropsWithChildren } from "react";
+
+import { useRouter } from "next/router";
+
+import { useAuthStore } from "@/states/authStore";
+import { useModalStore } from "@/states/modalStore";
+
+import Loader from "@/components/Layout/Loader/Loader";
+
+export default function AuthLayout({ children }: PropsWithChildren) {
+  const router = useRouter();
+
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const isAuthReady = useAuthStore((state) => state.isAuthReady);
+  const openModal = useModalStore((state) => state.openModal);
+
+  useEffect(() => {
+    if (isAuthReady && !isLoggedIn) {
+      openModal({ type: "LOGIN" });
+      router.push("/");
+    }
+  }, [isAuthReady, isLoggedIn, openModal, router]);
+
+  if (!isAuthReady || !isLoggedIn) {
+    return <Loader />;
+  }
+
+  return children;
+}

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import router from "next/router";
 
 import { useMutation } from "react-query";
@@ -7,7 +7,6 @@ import { AxiosError } from "axios";
 import { CreateFeedRequest, IdResponse, postFeeds } from "@/api/feeds/postFeeds";
 
 import { useModalStore } from "@/states/modalStore";
-import { useAuthStore } from "@/states/authStore";
 
 import FeedForm from "@/components/Upload/FeedForm/FeedForm";
 
@@ -16,17 +15,9 @@ import { imageUrl as imageDomain } from "@/constants/imageUrl";
 import { useToast } from "@/hooks/useToast";
 
 export default function Upload() {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const openModal = useModalStore((state) => state.openModal);
   const { showToast } = useToast();
   const hasUnsavedChangesRef = useRef(false);
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      showToast("로그인 후 작성 가능합니다.", "warning");
-      router.push("/");
-    }
-  }, [isLoggedIn, router, showToast]);
 
   const { mutate: uploadFeed, isLoading } = useMutation<IdResponse, AxiosError, CreateFeedRequest>(
     postFeeds,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,7 @@ export default function App({ Component, pageProps }: AppProps) {
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   const setUserId = useAuthStore((state) => state.setUserId);
+  const setIsAuthReady = useAuthStore((state) => state.setIsAuthReady);
   const access_token = useAuthStore((state) => state.access_token);
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const user_id = useAuthStore((state) => state.user_id);
@@ -45,7 +46,8 @@ export default function App({ Component, pageProps }: AppProps) {
         }
       }
     }
-  }, [pageProps, setAccessToken, setIsLoggedIn, setUserId]);
+    setIsAuthReady(true);
+  }, [pageProps, setAccessToken, setIsLoggedIn, setUserId, setIsAuthReady]);
 
   useEffect(() => {
     if (isLoggedIn) {

--- a/src/pages/board/write.tsx
+++ b/src/pages/board/write.tsx
@@ -1,8 +1,11 @@
-import { InitialPageMeta } from "@/components/MetaData/MetaData";
-import { serviceUrl } from "@/constants/serviceurl";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+
+import { InitialPageMeta } from "@/components/MetaData/MetaData";
 import BoardWrite from "@/components/Board/BoardWrite/BoardWrite";
+import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
+
+import { serviceUrl } from "@/constants/serviceurl";
 
 export default function BoardWritePage() {
   const router = useRouter();
@@ -14,9 +17,9 @@ export default function BoardWritePage() {
   }, [router.asPath]);
 
   return (
-    <>
+    <AuthLayout>
       <InitialPageMeta title={OGTitle} url={OGUrl} />
       <BoardWrite />
-    </>
+    </AuthLayout>
   );
 }

--- a/src/pages/following.tsx
+++ b/src/pages/following.tsx
@@ -1,4 +1,5 @@
 import FollowingPage from "@/components/FollowingPage/FollowingPage";
+import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
 import { InitialPageMeta } from "@/components/MetaData/MetaData";
 import { serviceUrl } from "@/constants/serviceurl";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
@@ -23,9 +24,9 @@ export default function Following() {
   }, []);
 
   return (
-    <>
+    <AuthLayout>
       <InitialPageMeta title={OGTitle} url={OGUrl} />
       <FollowingPage />
-    </>
+    </AuthLayout>
   );
 }

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,10 +1,13 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+
+import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
 import { InitialPageMeta } from "@/components/MetaData/MetaData";
 import MyPage from "@/components/MyPage/MyPage";
+
 import { serviceUrl } from "@/constants/serviceurl";
+
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import { useAuthStore } from "@/states/authStore";
 
 export default function Mypage() {
   const router = useRouter();
@@ -28,7 +31,6 @@ export default function Mypage() {
   const [OGTitle, setOGTitle] = useState<string>(getTabData());
   const [OGUrl, setOGUrl] = useState(serviceUrl);
   const { restoreScrollPosition } = useScrollRestoration("mypage-scroll");
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   useEffect(() => {
     setOGUrl(`${serviceUrl}/${router.asPath}`);
@@ -45,16 +47,10 @@ export default function Mypage() {
     }
   }, []);
 
-  useEffect(() => {
-    if (!isLoggedIn) {
-      router.push("/");
-    }
-  }, [isLoggedIn, router]);
-
   return (
-    <>
+    <AuthLayout>
       <InitialPageMeta title={OGTitle} url={OGUrl} />
       <MyPage />
-    </>
+    </AuthLayout>
   );
 }

--- a/src/pages/write.tsx
+++ b/src/pages/write.tsx
@@ -1,8 +1,11 @@
-import { InitialPageMeta } from "@/components/MetaData/MetaData";
-import { serviceUrl } from "@/constants/serviceurl";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+
+import { InitialPageMeta } from "@/components/MetaData/MetaData";
 import Upload from "@/components/Upload/Upload";
+import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
+
+import { serviceUrl } from "@/constants/serviceurl";
 
 export default function write() {
   const router = useRouter();
@@ -14,9 +17,9 @@ export default function write() {
   }, [router.asPath]);
 
   return (
-    <>
+    <AuthLayout>
       <InitialPageMeta title={OGTitle} url={OGUrl} />
       <Upload />
-    </>
+    </AuthLayout>
   );
 }

--- a/src/states/authStore.ts
+++ b/src/states/authStore.ts
@@ -4,9 +4,11 @@ interface AuthState {
   access_token: string;
   isLoggedIn: boolean;
   user_id: string;
+  isAuthReady: boolean;
   setAccessToken: (token: string) => void;
   setIsLoggedIn: (loggedIn: boolean) => void;
   setUserId: (id: string) => void;
+  setIsAuthReady: (ready: boolean) => void;
   clearAuth: () => void;
 }
 
@@ -14,10 +16,12 @@ export const useAuthStore = create<AuthState>((set) => ({
   access_token: "",
   isLoggedIn: false,
   user_id: "",
+  isAuthReady: false,
   setAccessToken: (token) => set({ access_token: token }),
   setIsLoggedIn: (loggedIn) => set({ isLoggedIn: loggedIn }),
   setUserId: (id) => set({ user_id: id }),
+  setIsAuthReady: (ready) => set({ isAuthReady: ready }),
   clearAuth: () => {
-    set({ access_token: "", isLoggedIn: false, user_id: "" });
+    set({ access_token: "", isLoggedIn: false, user_id: "", isAuthReady: true });
   },
 }));


### PR DESCRIPTION
### 🔎 작업 내용
- `authStore.ts` 수정
  - `isAuthReady` 상태를 추가하여 앱의 초기 인증 확인 절차가 완료되었는지 여부를 추적합니다. 이를 통해 비동기적으로 `localStorage`를 확인하는 동안 발생할 수 있는 race condition를 방지합니다.
- `_app.tsx` 로직 개선
  - 앱이 처음 로드될 때 `localStorage`에서 인증 토큰을 확인하고, `zustand` 스토어의 상태를 업데이트하는 로직을 중앙화했습니다.
  - 인증 확인이 완료되면 `isAuthReady`를 `true`로 설정하여, 애플리케이션의 다른 모든 컴포넌트가 안정적으로 인증 상태를 참조할 수 있도록 합니다.
- `<AuthLayout />` 컴포넌트 신규 생성
  - 로그인이 필요한 페이지를 감싸는 `AuthLayout` 컴포넌트를 새로 만들었습니다.
  - 이 컴포넌트는 `isAuthReady`와 `isLoggedIn` 상태를 확인합니다.
    - 인증 확인이 완료될 때까지 로딩 UI(Loader)를 보여줍니다.
    - 인증 확인 후 로그인이 되어있지 않으면, 로그인 모달을 띄우고 홈페이지(/)로 리디렉션합니다.
- `following.tsx` 리팩토링
  - 기존에 `following.tsx` 페이지 내에 있던 복잡한 인증 관련 `useEffect` 로직을 모두 제거했습니다.
이제 페이지 전체를 `<AuthLayout>`으로 감싸는 간결한 구조로 변경하여, 모든 인증 관련 책임을 `AuthLayout`에 위임합니다.

### 📸 구현영상
#### 팔로우
https://github.com/user-attachments/assets/9b33f73b-4060-4a3f-a51c-e7d09ed0c1fb

#### 그림 업로드
https://github.com/user-attachments/assets/a7181700-1d84-4f5f-adb6-3e88bd8efd2f

#### 마이페이지
https://github.com/user-attachments/assets/e240d9be-e096-4cf4-a048-d498360bf463

#### 글 업로드
https://github.com/user-attachments/assets/5e6e36d1-0360-45d1-b15e-ff7dab43c5b3


### :loudspeaker: 전달사항
- 로그인이 필요한 페이지인 경우 `<AuthLayout>` 컴포넌트로 감싸주세요.

### 🚀 이슈
#112