### PR TITLE
[Fix] 프로필 커버 이미지 관리 기능 개선

### DIFF
--- a/src/components/Modal/Background/Background.tsx
+++ b/src/components/Modal/Background/Background.tsx
@@ -23,7 +23,7 @@ export default function Background({ imageSrc, file }: BackgroundProps) {
   useIsMobile();
   const closeModal = useModalStore((state) => state.closeModal);
   const { showToast } = useToast();
-  const [crop, setCrop] = useState<Crop>({
+  const [crop, setCrop] = useState<PercentCrop>({
     unit: "%",
     width: 100,
     height: 30,
@@ -136,7 +136,7 @@ export default function Background({ imageSrc, file }: BackgroundProps) {
     const aspectRatio = viewportWidth / 400;
     const cropHeight = width / aspectRatio;
 
-    const newCrop: Crop = {
+    const newCrop: PercentCrop = {
       unit: "%",
       width: 100,
       height: (cropHeight / height) * 100,
@@ -144,6 +144,7 @@ export default function Background({ imageSrc, file }: BackgroundProps) {
       y: 0,
     };
     setCrop(newCrop);
+    setCompletedCrop(newCrop);
   };
 
   if (!viewportWidth) return null;

--- a/src/components/Modal/Background/Background.tsx
+++ b/src/components/Modal/Background/Background.tsx
@@ -16,9 +16,10 @@ import { useMyData } from "@/api/users/getMe";
 interface BackgroundProps {
   imageSrc: string;
   file: File;
+  onUploadSuccess?: () => void;
 }
 
-export default function Background({ imageSrc, file }: BackgroundProps) {
+export default function Background({ imageSrc, file, onUploadSuccess }: BackgroundProps) {
   const { refetch } = useMyData();
   useIsMobile();
   const closeModal = useModalStore((state) => state.closeModal);
@@ -124,7 +125,10 @@ export default function Background({ imageSrc, file }: BackgroundProps) {
       showToast("커버 이미지가 변경되었습니다!", "success");
       closeModal();
       refetch();
-      router.reload();
+
+      if (onUploadSuccess) {
+        onUploadSuccess();
+      }
     } catch (error) {
       console.error("Cover image upload error:", error);
       showToast("커버 이미지 업로드에 실패했습니다.", "error");

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import styles from "./Modal.module.scss";
 import { useModalStore } from "@/states/modalStore";
 import { usePreventScroll } from "@/hooks/usePreventScroll";
@@ -27,6 +27,7 @@ import ShareProfile from "./ShareProfile/ShareProfile";
 export default function Modal() {
   const router = useRouter();
   const { isOpen, type, data, isFill, isComfirm, onClick, openModal, closeModal } = useModalStore();
+  const modalRef = useRef<EventTarget | null>(null);
 
   usePreventScroll(isOpen);
 
@@ -60,6 +61,19 @@ export default function Modal() {
     if (type === "ALBUM-EDIT") {
       router.reload();
     }
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      modalRef.current = e.target;
+    }
+  };
+
+  const handleMouseUp = (e: React.MouseEvent) => {
+    if (modalRef.current && modalRef.current === e.target) {
+      handleCloseModal();
+    }
+    modalRef.current = null;
   };
 
   const renderModalContent = () => {
@@ -125,7 +139,7 @@ export default function Modal() {
           {renderModalContent()}
         </div>
       ) : (
-        <div className={styles.overlay} onClick={handleCloseModal}>
+        <div className={styles.overlay} onMouseDown={handleMouseDown} onMouseUp={handleMouseUp}>
           {isComfirm ? (
             <div className={styles.comfirmModal}>
               <div className={styles.titleContainer}>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -26,7 +26,7 @@ import ShareProfile from "./ShareProfile/ShareProfile";
 
 export default function Modal() {
   const router = useRouter();
-  const { isOpen, type, data, isFill, isComfirm, onClick, openModal, closeModal } = useModalStore();
+  const { isOpen, type, data, isFill, isComfirm, closeModal } = useModalStore();
   const modalRef = useRef<EventTarget | null>(null);
 
   usePreventScroll(isOpen);
@@ -93,7 +93,13 @@ export default function Modal() {
       case "SHARE-PROFILE":
         return <ShareProfile {...data} />;
       case "BACKGROUND":
-        return <Background imageSrc={data?.imageSrc} file={data?.file} />;
+        return (
+          <Background
+            imageSrc={data?.imageSrc}
+            file={data?.file}
+            onUploadSuccess={data?.onUploadSuccess}
+          />
+        );
       case "FOLLOWER":
         return <Follow initialTab="follower" />;
       case "FOLLOWING":

--- a/src/components/ProfilePage/Profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ProfilePage/Profile/ProfileCover/ProfileCover.tsx
@@ -30,6 +30,10 @@ export default function ProfileCover({
     }
   };
 
+  const handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    e.currentTarget.value = "";
+  };
+
   if (!userData) return null;
 
   return (
@@ -75,7 +79,14 @@ export default function ProfileCover({
           )}
         </div>
       )}
-      <input ref={inputRef} type="file" accept="image/*" hidden onChange={handleAddCover} />
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={handleAddCover}
+        onClick={handleInputClick}
+      />
     </>
   );
 }

--- a/src/components/ProfilePage/Profile/ProfileCover/ProfileCover.tsx
+++ b/src/components/ProfilePage/Profile/ProfileCover/ProfileCover.tsx
@@ -34,7 +34,7 @@ export default function ProfileCover({
 
   return (
     <>
-      {userData.backgroundImage !== null ? (
+      {userData.backgroundImage ? (
         <div className={styles.backgroundImage}>
           <img
             src={coverImage}

--- a/src/hooks/useCoverImage.ts
+++ b/src/hooks/useCoverImage.ts
@@ -7,7 +7,6 @@ import { postPresignedUrl } from "@/api/aws/postPresigned";
 import { putBackgroundImage } from "@/api/users/putMeImage";
 import { deleteMyBackgroundImage } from "@/api/users/deleteMeImage";
 import { AxiosError } from "axios";
-import router from "next/router";
 import type { UserProfileResponse as UserData } from "@grimity/dto";
 
 export const useCoverImage = (
@@ -30,7 +29,7 @@ export const useCoverImage = (
       const imageUrl = URL.createObjectURL(file);
       openModal({
         type: "BACKGROUND",
-        data: { imageSrc: imageUrl, file },
+        data: { imageSrc: imageUrl, file, onUploadSuccess: refetchUserData },
       });
       return;
     }
@@ -73,7 +72,6 @@ export const useCoverImage = (
         setCoverImage(userData.backgroundImage || "/image/default-cover.png");
       }
       refetchUserData();
-      router.reload();
     },
     onError: (error: AxiosError) => {
       showToast("커버 이미지 삭제에 실패했습니다.", "error");


### PR DESCRIPTION
### 이슈번호
- #108

### 🔎 작업 내용
- **이미지 크롭 모달 안정성 향상**
  - `react-image-crop` 사용 시, 크롭 영역을 조절하다 마우스가 모달 밖으로 나가면 모달이 닫히던 문제를 해결했습니다. (`onClick` -> `onMouseDown/Up` 로직 변경)
  - 이미지를 불러온 후, 크롭 영역을 따로 지정하지 않고 바로 저장할 때 발생하던 오류를 수정했습니다. (`completedCrop` 초기값 설정)
- **화면 깜빡임 현상 제거**
  -  커버 이미지 변경 및 삭제 시 `router.reload()`로 인해 발생하던 전체 페이지 새로고침을 제거했습니다.
  -  대신 `react-query`의 `refetch`를 사용하여 데이터만 비동기적으로 갱신하도록 변경하여, 사용자가 부드러운 UI 업데이트를 경험할 수 있도록 개선했습니다.
- **데이터 동기화 문제 해결**
  - 커버 이미지 변경 후, 프로필 페이지의 데이터가 실시간으로 갱신되지 않던 문제를 해결했습니다.
  - 모달과 프로필 페이지 간에 데이터 갱신 함수(`refetch`)를 공유하여, 이미지 업로드 성공 시 프로필 데이터가 올바르게 다시 로드되도록 수정했습니다.
- **파일 재선택 버그 수정**
  - 동일한 커버 이미지 파일을 연속으로 선택하면 `onChange` 이벤트가 발생하지 않던 버그를 수정했습니다.
  - 파일 입력(`input`) 컴포넌트를 클릭할 때마다 값을 초기화하여, 항상 파일 선택 이벤트를 감지하도록 변경했습니다.

### 📸 영상
- 영상을 올릴려고 했으나, 용량이 커서 해당 브런치에 접근하셔서 확인해주시면 감사드리겠습니다 :)
