### PR TITLE
[Fix] 게시물 - 업로드 중복 수정 및 피드 제출 후 불필요한 확인 모달 버그 수정

### DIFF
--- a/src/api/feeds/putFeedsId.ts
+++ b/src/api/feeds/putFeedsId.ts
@@ -2,7 +2,12 @@ import axiosInstance from "@/constants/baseurl";
 import type { CreateFeedRequest } from "@grimity/dto";
 export type { CreateFeedRequest };
 
-export async function putEditFeeds(id: string, data: CreateFeedRequest): Promise<Response> {
+export interface PutEditFeedsProps {
+  id: string;
+  data: CreateFeedRequest;
+}
+
+export async function putEditFeeds({ id, data }: PutEditFeedsProps): Promise<Response> {
   const requestData = {
     ...data,
     ...(data.albumId ? { albumId: data.albumId } : {}),

--- a/src/components/Modal/FeedConfirm/index.tsx
+++ b/src/components/Modal/FeedConfirm/index.tsx
@@ -54,6 +54,7 @@ const FeedConfirm = ({ id, data, isEditMode, close }: FeedConfirmProps) => {
       showToast("업로드 중 오류가 발생했습니다. 다시 시도해주세요.", "error");
     },
   });
+
   const { mutate: editFeed, isLoading: isEditLoading } = useMutation(putEditFeeds, {
     onSuccess: () => {
       showToast("수정이 완료되었습니다!", "success");

--- a/src/components/Modal/FeedConfirm/index.tsx
+++ b/src/components/Modal/FeedConfirm/index.tsx
@@ -1,0 +1,103 @@
+import { postFeeds } from "@/api/feeds/postFeeds";
+import Button from "@/components/Button/Button";
+import styles from "@/components/Modal/Modal.module.scss";
+import { useToast } from "@/hooks/useToast";
+import { CreateFeedRequest } from "@grimity/dto";
+import { useMutation, useQueryClient } from "react-query";
+import { imageUrl as imageDomain } from "@/constants/imageUrl";
+import { AxiosError } from "axios";
+import { putEditFeeds } from "@/api/feeds/putFeedsId";
+import { useModal } from "@/hooks/useModal";
+import UploadModal from "@/components/Modal/Upload/Upload";
+import { useRouter } from "next/router";
+
+interface FeedConfirmProps {
+  id?: string;
+  data: CreateFeedRequest;
+  isEditMode: boolean;
+  close: () => void;
+}
+
+const FeedConfirm = ({ id, data, isEditMode, close }: FeedConfirmProps) => {
+  const router = useRouter();
+
+  const { showToast } = useToast();
+  const { openModal } = useModal();
+  const queryClient = useQueryClient();
+
+  const { mutate: uploadFeed, isLoading: isUploadLoading } = useMutation(postFeeds, {
+    onSuccess: (response, variables) => {
+      if (!response.id) {
+        showToast("업로드 중 문제가 발생했습니다. 다시 시도해주세요.", "error");
+        return;
+      }
+
+      const imageUrl = `${imageDomain}/${variables.thumbnail}`;
+      close();
+
+      openModal((closeUploadModal) => (
+        <UploadModal
+          feedId={response.id}
+          title={variables.title}
+          image={imageUrl}
+          close={closeUploadModal}
+        />
+      ));
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 400) {
+          showToast("잘못된 요청입니다. 입력값을 확인해주세요.", "error");
+          return;
+        }
+      }
+      showToast("업로드 중 오류가 발생했습니다. 다시 시도해주세요.", "error");
+    },
+  });
+  const { mutate: editFeed, isLoading: isEditLoading } = useMutation(putEditFeeds, {
+    onSuccess: () => {
+      showToast("수정이 완료되었습니다!", "success");
+      queryClient.invalidateQueries({ queryKey: ["feeds", id] });
+      queryClient.invalidateQueries({ queryKey: ["feeds"] });
+      router.push(`/feeds/${id}`);
+      close();
+    },
+    onError: (error: AxiosError) => {
+      showToast("수정 중 오류가 발생했습니다. 다시 시도해주세요.", "error");
+      if (error.response?.status === 400) {
+        showToast("잘못된 요청입니다. 입력값을 확인해주세요.", "error");
+      }
+    },
+  });
+
+  const handleSubmit = () => {
+    if (isEditMode && id) {
+      editFeed({ id, data });
+    } else {
+      uploadFeed(data);
+    }
+  };
+
+  return (
+    <div className={styles.comfirmModal}>
+      <div className={styles.titleContainer}>
+        <h2 className={styles.title}>그림을 {isEditMode ? "수정" : "업로드"}할까요?</h2>
+      </div>
+      <div className={styles.btnsContainer}>
+        <Button size="l" type="outlined-assistive" onClick={close}>
+          취소
+        </Button>
+        <Button
+          size="l"
+          type="filled-primary"
+          onClick={handleSubmit}
+          disabled={isUploadLoading || isEditLoading}
+        >
+          {isEditMode ? "수정" : "업로드"}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default FeedConfirm;

--- a/src/components/Modal/FeedConfirm/index.tsx
+++ b/src/components/Modal/FeedConfirm/index.tsx
@@ -15,10 +15,11 @@ interface FeedConfirmProps {
   id?: string;
   data: CreateFeedRequest;
   isEditMode: boolean;
+  onSuccessCallback?: () => void;
   close: () => void;
 }
 
-const FeedConfirm = ({ id, data, isEditMode, close }: FeedConfirmProps) => {
+const FeedConfirm = ({ id, data, isEditMode, onSuccessCallback, close }: FeedConfirmProps) => {
   const router = useRouter();
 
   const { showToast } = useToast();
@@ -31,7 +32,7 @@ const FeedConfirm = ({ id, data, isEditMode, close }: FeedConfirmProps) => {
         showToast("업로드 중 문제가 발생했습니다. 다시 시도해주세요.", "error");
         return;
       }
-
+      onSuccessCallback?.();
       const imageUrl = `${imageDomain}/${variables.thumbnail}`;
       close();
 
@@ -57,6 +58,7 @@ const FeedConfirm = ({ id, data, isEditMode, close }: FeedConfirmProps) => {
 
   const { mutate: editFeed, isLoading: isEditLoading } = useMutation(putEditFeeds, {
     onSuccess: () => {
+      onSuccessCallback?.();
       showToast("수정이 완료되었습니다!", "success");
       queryClient.invalidateQueries({ queryKey: ["feeds", id] });
       queryClient.invalidateQueries({ queryKey: ["feeds"] });

--- a/src/components/Modal/Portal/index.tsx
+++ b/src/components/Modal/Portal/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ModalPortalProps {
+  children: React.ReactNode;
+  selector?: string;
+}
+
+function ModalPortal({ children, selector = "#modal-root" }: ModalPortalProps) {
+  const [el, setEl] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    let portalRoot = document.querySelector(selector) as HTMLElement;
+    if (!portalRoot) {
+      portalRoot = document.createElement("div");
+      portalRoot.setAttribute("id", selector.replace("#", ""));
+      document.body.appendChild(portalRoot);
+    }
+    setEl(portalRoot);
+  }, [selector]);
+
+  if (!el) return null;
+
+  return createPortal(children, el);
+}
+
+export default ModalPortal;

--- a/src/components/Modal/Provider/index.tsx
+++ b/src/components/Modal/Provider/index.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren } from "react";
+
+import { useNewModalStore } from "@/states/modalStore";
+
+import ModalPortal from "@/components/Modal/Portal";
+
+import styles from "@/components/Modal/Modal.module.scss";
+
+function ModalProvider({ children }: PropsWithChildren) {
+  const { modals, closeModal } = useNewModalStore();
+
+  return (
+    <>
+      {children}
+      <ModalPortal>
+        {modals.map(({ id, content, props }) => {
+          const handleClose = () => closeModal(id);
+          const node = typeof content === "function" ? content(handleClose) : content;
+
+          return (
+            <div key={id} className={styles.overlay} onClick={handleClose}>
+              <div onClick={(e) => e.stopPropagation()} {...props}>
+                {node}
+              </div>
+            </div>
+          );
+        })}
+      </ModalPortal>
+    </>
+  );
+}
+
+export default ModalProvider;

--- a/src/components/Modal/Upload/Upload.module.scss
+++ b/src/components/Modal/Upload/Upload.module.scss
@@ -1,13 +1,15 @@
 @use "@/styles/globals.scss" as *;
 
 .container {
-  width: 100%;
   height: fit-content;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  padding-top: 28px;
+  background-color: $gray0;
+  width: 404px;
+  border-radius: 12px;
+  padding: 40px 32px;
 
   .uploadBtn {
     display: flex;

--- a/src/components/Modal/Upload/Upload.tsx
+++ b/src/components/Modal/Upload/Upload.tsx
@@ -1,16 +1,21 @@
-import { useToast } from "@/hooks/useToast";
-import styles from "./Upload.module.scss";
-import { useModalStore } from "@/states/modalStore";
-import Button from "@/components/Button/Button";
-import { UploadModalProps } from "./Upload.types";
+import { useRouter } from "next/router";
+
 import { useDeviceStore } from "@/states/deviceStore";
+
+import Button from "@/components/Button/Button";
 import { serviceUrl } from "@/constants/serviceurl";
 import IconComponent from "@/components/Asset/Icon";
 
-export default function UploadModal({ feedId, title, image }: UploadModalProps) {
+import { useToast } from "@/hooks/useToast";
+
+import type { UploadModalProps } from "@/components/Modal/Upload/Upload.types";
+
+import styles from "@/components/Modal/Upload/Upload.module.scss";
+
+export default function UploadModal({ feedId, title, image, close }: UploadModalProps) {
   const { showToast } = useToast();
-  const openModal = useModalStore((state) => state.openModal);
-  const closeModal = useModalStore((state) => state.closeModal);
+  const router = useRouter();
+
   const url = `${serviceUrl}feeds/${feedId}`;
   const isMobile = useDeviceStore((state) => state.isMobile);
 
@@ -18,7 +23,6 @@ export default function UploadModal({ feedId, title, image }: UploadModalProps) 
     try {
       await navigator.clipboard.writeText(url);
       showToast("클립보드에 복사되었습니다.", "success");
-      closeModal();
     } catch {
       showToast("클립보드 복사에 실패했습니다.", "error");
     }
@@ -45,7 +49,7 @@ export default function UploadModal({ feedId, title, image }: UploadModalProps) 
       },
     });
 
-    closeModal();
+    close();
   };
 
   const handleTwitterShare = () => {
@@ -54,7 +58,8 @@ export default function UploadModal({ feedId, title, image }: UploadModalProps) 
   };
 
   const handleClose = () => {
-    openModal({ type: null, data: null, isComfirm: false });
+    router.push(url);
+    close();
   };
 
   return (

--- a/src/components/Modal/Upload/Upload.types.ts
+++ b/src/components/Modal/Upload/Upload.types.ts
@@ -2,4 +2,5 @@ export interface UploadModalProps {
   feedId: string;
   title: string;
   image: string;
+  close: () => void;
 }

--- a/src/components/Upload/EditFeeds/EditFeeds.tsx
+++ b/src/components/Upload/EditFeeds/EditFeeds.tsx
@@ -1,20 +1,19 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { useMutation, useQueryClient } from "react-query";
-import { AxiosError } from "axios";
-
 import { useDetails } from "@/api/feeds/getFeedsId";
-import { CreateFeedRequest, putEditFeeds } from "@/api/feeds/putFeedsId";
+import { CreateFeedRequest } from "@/api/feeds/putFeedsId";
 
 import { useAuthStore } from "@/states/authStore";
 
 import Loader from "@/components/Layout/Loader/Loader";
 import FeedForm from "@/components/Upload/FeedForm/FeedForm";
-
-import { FeedData } from "@/components/Upload/FeedForm/FeedForm.types";
+import FeedConfirm from "@/components/Modal/FeedConfirm";
 
 import { useToast } from "@/hooks/useToast";
+import { useModal } from "@/hooks/useModal";
+
+import type { FeedData } from "@/components/Upload/FeedForm/FeedForm.types";
 
 interface EditFeedsProps {
   id: string;
@@ -22,12 +21,11 @@ interface EditFeedsProps {
 
 export default function EditFeeds({ id }: EditFeedsProps) {
   const router = useRouter();
-  const hasUnsavedChangesRef = useRef(false);
 
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const user_id = useAuthStore((state) => state.user_id);
-  const queryClient = useQueryClient();
   const { showToast } = useToast();
+  const { openModal } = useModal();
 
   const { data: feedData, isLoading: isFetching } = useDetails(id);
 
@@ -41,25 +39,6 @@ export default function EditFeeds({ id }: EditFeedsProps) {
       router.push("/");
     }
   }, [isLoggedIn, router, user_id, feedData, showToast, isFetching]);
-
-  const { mutate: editFeed, isLoading: isUpdating } = useMutation(
-    (data: CreateFeedRequest) => putEditFeeds(id, data),
-    {
-      onSuccess: () => {
-        hasUnsavedChangesRef.current = false;
-        showToast("수정이 완료되었습니다!", "success");
-        queryClient.invalidateQueries({ queryKey: ["feeds", id] });
-        queryClient.invalidateQueries({ queryKey: ["feeds"] });
-        router.push(`/feeds/${id}`);
-      },
-      onError: (error: AxiosError) => {
-        showToast("수정 중 오류가 발생했습니다. 다시 시도해주세요.", "error");
-        if (error.response?.status === 400) {
-          showToast("잘못된 요청입니다. 입력값을 확인해주세요.", "error");
-        }
-      },
-    },
-  );
 
   if (isFetching) return <Loader />;
   if (!feedData) return <div>피드 데이터를 불러오지 못했습니다.</div>;
@@ -80,15 +59,8 @@ export default function EditFeeds({ id }: EditFeedsProps) {
   };
 
   const handleSubmit = (data: CreateFeedRequest) => {
-    editFeed(data);
+    openModal((close) => <FeedConfirm isEditMode id={id} data={data} close={close} />);
   };
 
-  return (
-    <FeedForm
-      isEditMode={true}
-      initialValues={initialValues}
-      onSubmit={handleSubmit}
-      isLoading={isUpdating}
-    />
-  );
+  return <FeedForm isEditMode initialValues={initialValues} onSubmit={handleSubmit} />;
 }

--- a/src/components/Upload/EditFeeds/EditFeeds.tsx
+++ b/src/components/Upload/EditFeeds/EditFeeds.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 
 import { useDetails } from "@/api/feeds/getFeedsId";
@@ -21,6 +21,10 @@ interface EditFeedsProps {
 
 export default function EditFeeds({ id }: EditFeedsProps) {
   const router = useRouter();
+
+  const [formHandlers, setFormHandlers] = useState<{ resetUnsavedChanges: () => void } | null>(
+    null,
+  );
 
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const user_id = useAuthStore((state) => state.user_id);
@@ -59,8 +63,23 @@ export default function EditFeeds({ id }: EditFeedsProps) {
   };
 
   const handleSubmit = (data: CreateFeedRequest) => {
-    openModal((close) => <FeedConfirm isEditMode id={id} data={data} close={close} />);
+    openModal((close) => (
+      <FeedConfirm
+        isEditMode
+        id={id}
+        data={data}
+        close={close}
+        onSuccessCallback={() => formHandlers?.resetUnsavedChanges()}
+      />
+    ));
   };
 
-  return <FeedForm isEditMode initialValues={initialValues} onSubmit={handleSubmit} />;
+  return (
+    <FeedForm
+      isEditMode
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onStateUpdate={setFormHandlers}
+    />
+  );
 }

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -24,7 +24,12 @@ import { removeUrlPrefix } from "@/utils/removeUrlPrefix";
 
 import styles from "@/components/Upload/FeedForm/FeedForm.module.scss";
 
-export default function FeedForm({ isEditMode, initialValues, onSubmit }: FeedFormProps) {
+export default function FeedForm({
+  isEditMode,
+  initialValues,
+  onSubmit,
+  onStateUpdate,
+}: FeedFormProps) {
   const [images, setImages] = useState<{ name: string; originalName: string; url: string }[]>([]);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
@@ -46,6 +51,15 @@ export default function FeedForm({ isEditMode, initialValues, onSubmit }: FeedFo
   const isTablet = useDeviceStore((state) => state.isTablet);
 
   useIsMobile();
+
+  const resetUnsavedChanges = () => {
+    hasUnsavedChangesRef.current = false;
+    setHasUnsavedChanges(false);
+  };
+
+  useEffect(() => {
+    onStateUpdate?.({ resetUnsavedChanges });
+  }, [onStateUpdate]);
 
   const handleOpenAlbumSelect = () => {
     const data = {

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -46,6 +46,7 @@ export default function FeedForm({
 
   const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isMobile = useDeviceStore((state) => state.isMobile);
   const isTablet = useDeviceStore((state) => state.isTablet);
@@ -451,8 +452,25 @@ export default function FeedForm({
     return isEditMode ? "수정" : "업로드";
   };
 
+  const handleImageUpload = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleClickFileInput = (e: React.MouseEvent<HTMLInputElement>) => {
+    e.currentTarget.value = "";
+  };
+
   return (
     <div className={styles.background}>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/png, image/jpeg, image/jpg, image/webp"
+        hidden
+        onClick={handleClickFileInput}
+        onChange={(e) => e.target.files && uploadImagesToServer(e.target.files)}
+      />
       <div className={styles.container}>
         <div className={styles.sectionContainer}>
           <section className={styles.imageSection} onDrop={handleDrop} onDragOver={handleDragOver}>
@@ -486,9 +504,8 @@ export default function FeedForm({
                 </Droppable>
               </DragDropContext>
 
-              {/* PC */}
-              {!isMobile && !isTablet && images.length < 10 && (
-                <label htmlFor="file-upload" className={styles.uploadBtn}>
+              {((!isMobile && !isTablet) || images.length === 0) && images.length < 10 && (
+                <div role="button" onClick={handleImageUpload} className={styles.uploadBtn}>
                   <div tabIndex={0}>
                     <img
                       src="/image/upload.svg"
@@ -497,65 +514,19 @@ export default function FeedForm({
                       alt="그림 추가"
                       loading="lazy"
                     />
-                    <input
-                      id="file-upload"
-                      type="file"
-                      multiple
-                      accept="image/png, image/jpeg, image/jpg, image/webp"
-                      hidden
-                      onChange={(e) => e.target.files && uploadImagesToServer(e.target.files)}
-                    />
                   </div>
-                </label>
-              )}
-              {/* 모바일, 태블릿: 이미지 없을 때 */}
-              {(isMobile || isTablet) && images.length === 0 && images.length < 10 && (
-                <label htmlFor="file-upload" className={styles.uploadBtn}>
-                  <div tabIndex={0}>
-                    <img
-                      src="/image/upload.svg"
-                      width={240}
-                      height={240}
-                      alt="그림 추가"
-                      loading="lazy"
-                    />
-                    <input
-                      id="file-upload"
-                      type="file"
-                      multiple
-                      accept="image/png, image/jpeg, image/jpg, image/webp"
-                      hidden
-                      onChange={(e) => e.target.files && uploadImagesToServer(e.target.files)}
-                    />
-                  </div>
-                </label>
+                </div>
               )}
             </div>
-            <input
-              id="file-upload"
-              type="file"
-              multiple
-              accept="image/png, image/jpeg, image/jpg, image/webp"
-              style={{ display: "none" }}
-              onChange={(e) => e.target.files && uploadImagesToServer(e.target.files)}
-            />
           </section>
-          {/* 모바일, 태블릿: 이미지가 하나 이상일 때 */}
+
           {(isMobile || isTablet) && images.length > 0 && images.length < 10 && (
-            <label htmlFor="file-upload" style={{ width: "100%" }}>
+            <div role="button" onClick={handleImageUpload} style={{ width: "100%" }}>
               <div className={styles.imageAddBtn}>
                 <IconComponent name="mobileAddImage" size={16} />
                 이미지 추가
               </div>
-              <input
-                id="file-upload"
-                type="file"
-                multiple
-                accept="image/png, image/jpeg, image/jpg, image/webp"
-                hidden
-                onChange={(e) => e.target.files && uploadImagesToServer(e.target.files)}
-              />
-            </label>
+            </div>
           )}
           <section className={styles.writeSection}>
             <div className={styles.textField}>

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -24,12 +24,7 @@ import { removeUrlPrefix } from "@/utils/removeUrlPrefix";
 
 import styles from "@/components/Upload/FeedForm/FeedForm.module.scss";
 
-export default function FeedForm({
-  isEditMode,
-  initialValues,
-  onSubmit,
-  isLoading,
-}: FeedFormProps) {
+export default function FeedForm({ isEditMode, initialValues, onSubmit }: FeedFormProps) {
   const [images, setImages] = useState<{ name: string; originalName: string; url: string }[]>([]);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
@@ -132,7 +127,7 @@ export default function FeedForm({
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [hasUnsavedChanges]);
 
-  // 라우터 이벤트 핸들러
+  // // 라우터 이벤트 핸들러
   useEffect(() => {
     hasUnsavedChangesRef.current = hasUnsavedChanges;
   }, [hasUnsavedChanges]);
@@ -368,21 +363,7 @@ export default function FeedForm({
       return;
     }
 
-    openModal({
-      type: null,
-      data: {
-        title: `그림을 ${isEditMode ? "수정" : "업로드"}할까요?`,
-        confirmBtn: isEditMode ? "수정" : "업로드",
-        onClick: handleUpload,
-      },
-      isComfirm: true,
-    });
-  };
-
-  const handleUpload = async () => {
-    if (isLoading) return;
-
-    const feedData: CreateFeedRequest = {
+    const data: CreateFeedRequest = {
       title,
       cards: images.map((image) => removeUrlPrefix(image.name)),
       content,
@@ -391,7 +372,7 @@ export default function FeedForm({
       albumId: selectedAlbumId && selectedAlbumId.trim() !== "" ? selectedAlbumId : null,
     };
 
-    onSubmit(feedData);
+    onSubmit(data);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -453,9 +434,6 @@ export default function FeedForm({
   const isDisabled = title.trim() === "" || content.trim() === "" || images.length === 0;
 
   const buttonText = () => {
-    if (isLoading) {
-      return isEditMode ? "수정 중..." : "업로드 중...";
-    }
     return isEditMode ? "수정" : "업로드";
   };
 
@@ -675,12 +653,7 @@ export default function FeedForm({
           </section>
 
           {isMobile ? (
-            <Button
-              size="l"
-              type="filled-primary"
-              disabled={isDisabled || isLoading}
-              onClick={handleSubmit}
-            >
+            <Button size="l" type="filled-primary" disabled={isDisabled} onClick={handleSubmit}>
               {buttonText()}
             </Button>
           ) : (
@@ -688,7 +661,7 @@ export default function FeedForm({
               <Button
                 size="l"
                 type="filled-primary"
-                disabled={isDisabled || isLoading}
+                disabled={isDisabled}
                 onClick={handleSubmit}
                 width="200px"
               >

--- a/src/components/Upload/FeedForm/FeedForm.types.ts
+++ b/src/components/Upload/FeedForm/FeedForm.types.ts
@@ -1,4 +1,4 @@
-import { CreateFeedRequest } from "@/api/feeds/postFeeds";
+import { CreateFeedRequest } from "@grimity/dto";
 
 export interface FeedData {
   title: string;
@@ -14,5 +14,4 @@ export interface FeedFormProps {
   isEditMode: boolean;
   initialValues?: Partial<FeedData>;
   onSubmit: (data: CreateFeedRequest) => void;
-  isLoading: boolean;
 }

--- a/src/components/Upload/FeedForm/FeedForm.types.ts
+++ b/src/components/Upload/FeedForm/FeedForm.types.ts
@@ -14,4 +14,5 @@ export interface FeedFormProps {
   isEditMode: boolean;
   initialValues?: Partial<FeedData>;
   onSubmit: (data: CreateFeedRequest) => void;
+  onStateUpdate?: (handlers: { resetUnsavedChanges: () => void }) => void;
 }

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import FeedConfirm from "@/components/Modal/FeedConfirm";
 import FeedForm from "@/components/Upload/FeedForm/FeedForm";
 
@@ -7,10 +8,20 @@ import type { CreateFeedRequest } from "@grimity/dto";
 
 export default function Upload() {
   const { openModal } = useModal();
+  const [formHandlers, setFormHandlers] = useState<{ resetUnsavedChanges: () => void } | null>(
+    null,
+  );
 
   const handleSubmit = (data: CreateFeedRequest) => {
-    openModal((close) => <FeedConfirm isEditMode={false} data={data} close={close} />);
+    openModal((close) => (
+      <FeedConfirm
+        isEditMode={false}
+        data={data}
+        close={close}
+        onSuccessCallback={() => formHandlers?.resetUnsavedChanges()}
+      />
+    ));
   };
 
-  return <FeedForm isEditMode={false} onSubmit={handleSubmit} />;
+  return <FeedForm isEditMode={false} onSubmit={handleSubmit} onStateUpdate={setFormHandlers} />;
 }

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,53 +1,16 @@
-import { useRef } from "react";
-import router from "next/router";
-
-import { useMutation } from "react-query";
-import { AxiosError } from "axios";
-
-import { CreateFeedRequest, IdResponse, postFeeds } from "@/api/feeds/postFeeds";
-
-import { useModalStore } from "@/states/modalStore";
-
+import FeedConfirm from "@/components/Modal/FeedConfirm";
 import FeedForm from "@/components/Upload/FeedForm/FeedForm";
 
-import { imageUrl as imageDomain } from "@/constants/imageUrl";
+import { useModal } from "@/hooks/useModal";
 
-import { useToast } from "@/hooks/useToast";
+import type { CreateFeedRequest } from "@grimity/dto";
 
 export default function Upload() {
-  const openModal = useModalStore((state) => state.openModal);
-  const { showToast } = useToast();
-  const hasUnsavedChangesRef = useRef(false);
-
-  const { mutate: uploadFeed, isLoading } = useMutation<IdResponse, AxiosError, CreateFeedRequest>(
-    postFeeds,
-    {
-      onSuccess: (response: IdResponse, variables) => {
-        hasUnsavedChangesRef.current = false;
-        if (!response.id) {
-          showToast("업로드 중 문제가 발생했습니다. 다시 시도해주세요.", "error");
-          return;
-        }
-
-        const imageUrl = `${imageDomain}/${variables.thumbnail}`;
-        openModal({
-          type: "UPLOAD",
-          data: { feedId: response.id, title: variables.title, image: imageUrl },
-        });
-        router.push(`/feeds/${response.id}`);
-      },
-      onError: (error: AxiosError) => {
-        showToast("업로드 중 오류가 발생했습니다. 다시 시도해주세요.", "error");
-        if (error.response?.status === 400) {
-          showToast("잘못된 요청입니다. 입력값을 확인해주세요.", "error");
-        }
-      },
-    },
-  );
+  const { openModal } = useModal();
 
   const handleSubmit = (data: CreateFeedRequest) => {
-    uploadFeed(data);
+    openModal((close) => <FeedConfirm isEditMode={false} data={data} close={close} />);
   };
 
-  return <FeedForm isEditMode={false} onSubmit={handleSubmit} isLoading={isLoading} />;
+  return <FeedForm isEditMode={false} onSubmit={handleSubmit} />;
 }

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+import { ModalContent, useNewModalStore } from "@/states/modalStore";
+import { v4 as uuidv4 } from "uuid";
+
+export function useModal() {
+  const open = useNewModalStore((s) => s.openModal);
+  const close = useNewModalStore((s) => s.closeModal);
+
+  function openModal(content: ModalContent, props?: Record<string, any>) {
+    const id = uuidv4();
+    open(id, content, props);
+    return () => close(id);
+  }
+
+  return { openModal, onCloseAll: () => useNewModalStore.setState({ modals: [] }) };
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import Toast from "@/components/Toast/Toast";
 import Script from "next/script";
+import ModalProvider from "@/components/Modal/Provider";
 
 import "@/styles/globals.scss";
 import "@/styles/reset.css";
@@ -66,9 +67,11 @@ export default function App({ Component, pageProps }: AppProps) {
       <QueryClientProvider client={queryClient}>
         <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!}>
           <div className="body">
-            <Layout>
-              <Component {...pageProps} />
-            </Layout>
+            <ModalProvider>
+              <Layout>
+                <Component {...pageProps} />
+              </Layout>
+            </ModalProvider>
           </div>
           <Modal />
           <Toast />

--- a/src/states/modalStore.ts
+++ b/src/states/modalStore.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { create } from "zustand";
 
 export type ModalType =
@@ -58,4 +59,25 @@ export const useModalStore = create<ModalStore>((set) => ({
       onClick: undefined,
       isFill: false,
     })),
+}));
+
+export type ModalContent = ReactNode | ((close: () => void) => ReactNode);
+
+type NewModalType = {
+  id: string;
+  content: ModalContent;
+  props?: Record<string, any>;
+};
+
+interface NewModalState {
+  modals: NewModalType[];
+  openModal: (id: string, content: ModalContent, props?: Record<string, any>) => void;
+  closeModal: (id: string) => void;
+}
+
+export const useNewModalStore = create<NewModalState>((set) => ({
+  modals: [],
+  openModal: (id, content, props) =>
+    set((state) => ({ modals: [...state.modals, { id, content, props }] })),
+  closeModal: (id) => set((state) => ({ modals: state.modals.filter((m) => m.id !== id) })),
 }));


### PR DESCRIPTION
### 🔎 작업 내용
- **게시물 중복 생성 수정**
  - 게시물 업로드 시, 확인 모달의 버튼을 빠르게 중복 클릭하면 동일한 게시물이 여러 번 생성되는 문제를 수정했습니다. 
  - 기존에는 모달 내 버튼을 disabled 처리하려면, 새로운 모달 타입을 추가하고 컴포넌트를 별도로 만들어야 하는 번거로움이 있었습니다.
  - 이에 따라 중복 클릭을 방지할 수 있도록 새로운 모달 처리 로직을 도입했지만, 단순한 텍스트/버튼만 있는 모달도 있다 보니 현재 방식은 반복 작업이 필요합니다. → 로직을 좀 더 개선할 여지가 있어 추가 고민 중입니다.
  - `router.push`로 인해 활성화 안되어있던 업로드 성공 모달도 활성화할 수 있었습니다.
- **피드 제출 후 불필요한 확인 모달 버그 수정**
  - 피드 생성 또는 수정 후 페이지 이동 시, “저장되지 않은 변경사항이 있습니다”라는 확인 모달이 잘못 표시되던 문제를 수정했습니다.
  - 원인은, API 요청이 성공한 뒤 `router.push()`로 페이지가 이동할 때도 `FeedForm`의 `hasUnsavedChanges` 상태가 `true`로 남아 있어 `routeChangeStart` 이벤트에서 변경사항이 있다고 모달이 활성화되었습니다.
  - 그래서 오인하지 않도록 상태를 추가하여 이를 제어했습니다.
- 피드 업로드 파일 제거했다가 재등록 시 등록 안됐던 이슈를 수정했습니다.

### 📸 구현결과
#### 등록
https://github.com/user-attachments/assets/8b61c4a8-4dc9-4e5d-9d85-4bd551742115

<img width="457" alt="image" src="https://github.com/user-attachments/assets/ddd6beb4-d8e9-4c61-820d-52440f2086df" />

#### 수정하기 전 나가기

https://github.com/user-attachments/assets/a5e7dde1-e0dd-400a-ac12-56dc814f2016

#### 수정하고 페이지 이동

https://github.com/user-attachments/assets/935efe7e-3898-4976-9510-45b5bbe9a48a


