### PR TITLE
[Fix] 헤더 - 모달 중복 활성화 수정

### DIFF
--- a/src/components/Layout/AuthLayout/AuthLayout.tsx
+++ b/src/components/Layout/AuthLayout/AuthLayout.tsx
@@ -3,20 +3,23 @@ import { useEffect, PropsWithChildren } from "react";
 import { useRouter } from "next/router";
 
 import { useAuthStore } from "@/states/authStore";
-import { useModalStore } from "@/states/modalStore";
+
+import { useModal } from "@/hooks/useModal";
 
 import Loader from "@/components/Layout/Loader/Loader";
+import Login from "@/components/Modal/Login/Login";
 
 export default function AuthLayout({ children }: PropsWithChildren) {
   const router = useRouter();
 
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const isAuthReady = useAuthStore((state) => state.isAuthReady);
-  const openModal = useModalStore((state) => state.openModal);
+
+  const { openModal } = useModal();
 
   useEffect(() => {
     if (isAuthReady && !isLoggedIn) {
-      openModal({ type: "LOGIN" });
+      openModal((close) => <Login close={close} />);
       router.push("/");
     }
   }, [isAuthReady, isLoggedIn, openModal, router]);

--- a/src/components/Modal/Login/Login.module.scss
+++ b/src/components/Modal/Login/Login.module.scss
@@ -6,6 +6,9 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  border-radius: 12px;
+  padding: 40px 32px;
+  background-color: $gray0;
 
   @include Size("mobile") {
     height: 242px;

--- a/src/components/Modal/Login/Login.tsx
+++ b/src/components/Modal/Login/Login.tsx
@@ -8,6 +8,10 @@ import IconComponent from "@/components/Asset/Icon";
 import { AxiosError } from "axios";
 import axiosInstance from "@/constants/baseurl";
 
+interface LoginProps {
+  close: () => void;
+}
+
 interface AuthObj {
   access_token: string;
   expires_in: number;
@@ -30,14 +34,13 @@ interface LoginResponse {
 
 type LoginType = "GOOGLE" | "KAKAO";
 
-export default function Login() {
+export default function Login({ close }: LoginProps) {
   const APP_KEY = process.env.NEXT_PUBLIC_KAKAO_APP_KEY;
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   const setUserId = useAuthStore((state) => state.setUserId);
   const openModal = useModalStore((state) => state.openModal);
   const { showToast } = useToast();
-  const closeModal = useModalStore((state) => state.closeModal);
 
   const { mutateAsync, isLoading } = useMutation({
     mutationFn: async ({
@@ -57,7 +60,7 @@ export default function Login() {
       setAccessToken(data.accessToken);
       setIsLoggedIn(true);
       setUserId(data.id);
-      closeModal();
+      close();
       localStorage.setItem("access_token", data.accessToken);
       localStorage.setItem("refresh_token", data.refreshToken);
       localStorage.setItem("user_id", data.id);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -78,8 +78,6 @@ export default function Modal() {
 
   const renderModalContent = () => {
     switch (type) {
-      case "LOGIN":
-        return <Login />;
       case "NICKNAME":
         return <Nickname />;
       case "PROFILE-ID":

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect, RefObject } from "react";
+
+type Handler = (event: MouseEvent | TouchEvent) => void;
+
+export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: Handler,
+): void {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [ref, handler]);
+}

--- a/src/states/modalStore.ts
+++ b/src/states/modalStore.ts
@@ -2,7 +2,6 @@ import { ReactNode } from "react";
 import { create } from "zustand";
 
 export type ModalType =
-  | "LOGIN"
   | "NICKNAME"
   | "JOIN"
   | "PROFILE-ID"


### PR DESCRIPTION
### 🚀 이슈 번호
- #101 

### 🔎 작업 내용
- [x] 헤더의 알림창과 프로필 드롭다운이 중복으로 활성화 되던 문제를 수정했습니다.
- [x] `useOnClickOutside` hook을 만들어 외부 클릭 시 함수를 넘겨 해당 함수가 작동할 수 있게 했습니다.

### 📸 스크린샷

https://github.com/user-attachments/assets/3cae8e51-74a3-465b-a33f-7d312185441e
