### PR TITLE
[Fix] 로그인 모달 수정 및 모달 활성화 시 스크롤 막기

### DIFF
--- a/src/components/Layout/Header/Header.module.scss
+++ b/src/components/Layout/Header/Header.module.scss
@@ -13,6 +13,10 @@
   align-items: center;
   z-index: 100;
 
+  :global(body.modalOpen) & {
+    width: calc(100% - var(--scrollbar-width));
+  }
+
   @include Drag;
 
   @include Size("mobile") {

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -32,8 +32,16 @@
     opacity: 0;
     @include Drag;
 
+    :global(body.modalOpen) & {
+      right: calc(40px + var(--scrollbar-width));
+    }
+
     @include Size("mobile") {
       right: 16px;
+
+      :global(body.modalOpen) & {
+        right: calc(16px + var(--scrollbar-width));
+      }
     }
 
     &:hover {

--- a/src/components/Modal/Login/Login.module.scss
+++ b/src/components/Modal/Login/Login.module.scss
@@ -10,10 +10,6 @@
   padding: 40px 32px;
   background-color: $gray0;
 
-  @include Size("mobile") {
-    height: 242px;
-  }
-
   .messageContainer {
     display: flex;
     flex-direction: column;

--- a/src/components/Modal/Provider/index.tsx
+++ b/src/components/Modal/Provider/index.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from "react";
 
 import { useNewModalStore } from "@/states/modalStore";
+import { usePreventScroll } from "@/hooks/usePreventScroll";
 
 import ModalPortal from "@/components/Modal/Portal";
 
@@ -8,6 +9,8 @@ import styles from "@/components/Modal/Modal.module.scss";
 
 function ModalProvider({ children }: PropsWithChildren) {
   const { modals, closeModal } = useNewModalStore();
+
+  usePreventScroll(modals.length > 0);
 
   return (
     <>

--- a/src/hooks/usePreventScroll.ts
+++ b/src/hooks/usePreventScroll.ts
@@ -1,15 +1,26 @@
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 
 export const usePreventScroll = (isOpen: boolean) => {
+  const setBodyStyleOpenModal = useCallback(() => {
+    const scrollBarWidth = window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.style.setProperty("--scrollbar-width", `${scrollBarWidth}px`);
+    document.body.classList.add("modalOpen");
+  }, []);
+
+  const setBodyStyleCloseModal = useCallback(() => {
+    document.documentElement.style.removeProperty("--scrollbar-width");
+    document.body.classList.remove("modalOpen");
+  }, []);
+
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = "hidden";
+      setBodyStyleOpenModal();
     } else {
-      document.body.style.overflow = "";
+      setBodyStyleCloseModal();
     }
 
     return () => {
-      document.body.style.overflow = "";
+      setBodyStyleCloseModal();
     };
-  }, [isOpen]);
+  }, [isOpen, setBodyStyleOpenModal, setBodyStyleCloseModal]);
 };

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -285,6 +285,13 @@ $max-width-content: 780px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-smooth: always;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+body.modalOpen {
+  overflow: hidden;
+  padding-right: var(--scrollbar-width);
 }
 
 @keyframes pulse {


### PR DESCRIPTION
### 이슈번호
- #122 

### 🔎 작업 내용
- 로그인 모달의 스타일을 수정했습니다.
- 모달이 활성화 되었을 때, 스크롤 기능을 막았습니다.
- 아래로 스크롤 된 이후 모달이 활성화 되었을 때, 스크롤바가 사라지면서 화면이 **Layout shift**가 발생했습니다. 
  - 스크롤바 크기에 맞게 `padding-right`을 추가하여 해당 문제를 해결했습니다.
  - 헤더와 플로팅 버튼은 `position: fixed`로 고정되어 있기 때문에, 모달이 열릴 때 `body`에 `openModal` 클래스명을 추가하여 스크롤바 너비와 `right` 값을 합산해 위치가 밀리지 않도록 조정했습니다.

### 📸 영상

https://github.com/user-attachments/assets/a0e2d83a-d8eb-429c-84c4-10b2ebb1c154

