### PR TITLE
[Fix] 팔로우 목록 클릭 시 잘못된 URL 이동 수정

### DIFF
--- a/src/components/Modal/Follow/Follow.tsx
+++ b/src/components/Modal/Follow/Follow.tsx
@@ -194,7 +194,7 @@ export default function Follow({ initialTab }: FollowProps) {
                     <p className={styles.description}>{follow.description}</p>
                   </div>
                 ) : (
-                  <div className={styles.nameContainer} onClick={() => handleClickUser(follow.id)}>
+                  <div className={styles.nameContainer} onClick={() => handleClickUser(follow.url)}>
                     <p className={styles.name}>{follow.name}</p>
                   </div>
                 )}


### PR DESCRIPTION
### 🔎 작업 내용
- 팔로우 목록 중 `description`이 없는 경우 `follow.id`로 잘못된 URL로 보내고 있어 이를 수정했습니다.

### 📸 스크린샷

**AS-IS**

https://github.com/user-attachments/assets/4cd99c62-aeeb-402e-b039-73a6260c6aaf

**TO-BE**

https://github.com/user-attachments/assets/90b4cd5e-f86f-47a7-827a-6227b918285b