### PR TITLE
[Refector] 반응형 로직 개선

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -1,16 +1,12 @@
 import styles from "./Board.module.scss";
 import BoardAll from "./BoardAll/BoardAll";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import Link from "next/link";
 import { PATH_ROUTES } from "@/constants/routes";
 import Icon from "@/components/Asset/IconTemp";
 
 export default function Board() {
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   return (
     <div className={styles.container}>

--- a/src/components/Board/BoardAll/AllCard/AllCard.tsx
+++ b/src/components/Board/BoardAll/AllCard/AllCard.tsx
@@ -12,7 +12,6 @@ import { deletePostsFeeds } from "@/api/posts/deletePostsId";
 import { useRouter } from "next/router";
 import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { SearchHighlightContext } from "@/pages/search";
 import Icon from "@/components/Asset/IconTemp";
 
@@ -32,8 +31,7 @@ export function getTypeLabel(type: string): string {
 
 export default function AllCard({ post, case: cardCase, hasChip = false }: AllCardProps) {
   const { highlight } = useContext(SearchHighlightContext);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
   const openModal = useModalStore((state) => state.openModal);
   const { showToast } = useToast();
 

--- a/src/components/Board/BoardAll/BoardAll.tsx
+++ b/src/components/Board/BoardAll/BoardAll.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { useAuthStore } from "@/states/authStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import Button from "@/components/Button/Button";
 import Icon from "@/components/Asset/IconTemp";
@@ -12,7 +11,7 @@ import SearchSection from "@/components/Board/BoardAll/SearchSection";
 import TabNavigation from "@/components/Board/BoardAll/TabNavigation";
 import Pagination from "@/components/Pagination";
 
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import { useBoardAll } from "@/components/Board/BoardAll/hooks/useBoardAll";
 
 import { PATH_ROUTES } from "@/constants/routes";
@@ -23,8 +22,7 @@ import styles from "@/components/Board/BoardAll/BoardAll.module.scss";
 
 export default function BoardAll({ isDetail, hasChip }: BoardAllProps) {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   const {
     searchBy,

--- a/src/components/Board/BoardWrite/PostForm/PostForm.tsx
+++ b/src/components/Board/BoardWrite/PostForm/PostForm.tsx
@@ -3,13 +3,11 @@ import dynamic from "next/dynamic";
 import Script from "next/script";
 import { Editor as TinyMCEEditor } from "tinymce";
 
-import { useDeviceStore } from "@/states/deviceStore";
-
 import Button from "@/components/Button/Button";
 import TextField from "@/components/TextField/TextField";
 import Loader from "@/components/Layout/Loader/Loader";
 
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import { useEditorImageUploader } from "@/hooks/useEditorImageUploader";
 
 import type { PostFormProps } from "./PostForm.types";
@@ -32,9 +30,7 @@ export default function PostForm({
   isSubmitting,
   submitButtonText,
 }: PostFormProps) {
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   const [isScriptLoaded, setIsScriptLoaded] = useState(false);
   const editorRef = useRef<TinyMCEEditor | null>(null);

--- a/src/components/Board/Detail/Comment/Comment.tsx
+++ b/src/components/Board/Detail/Comment/Comment.tsx
@@ -22,8 +22,8 @@ import {
   ParentPostCommentResponse,
 } from "@/api/posts-comments/getPostsComments";
 import { PostCommentProps, PostCommentWriter } from "./Comment.types";
-import { useDeviceStore } from "@/states/deviceStore";
 import { useRouter } from "next/router";
+import { useDeviceStore } from "@/states/deviceStore";
 
 type ToastType = "success" | "error" | "warning" | "information";
 
@@ -93,7 +93,7 @@ export default function PostComment({ postId, postWriterId }: PostCommentProps) 
   const { mutateAsync: postComment, isPending: isPostCommentPending } = usePostPostsComments();
   const [activeParentReplyId, setActiveParentReplyId] = useState<string | null>(null);
   const [activeChildReplyId, setActiveChildReplyId] = useState<string | null>(null);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { pathname } = useRouter();
 
   useEffect(() => {

--- a/src/components/Board/Detail/Detail.tsx
+++ b/src/components/Board/Detail/Detail.tsx
@@ -14,11 +14,10 @@ import ShareBtn from "@/components/Board/Detail/ShareBtn/ShareBtn";
 import PostComment from "@/components/Board/Detail/Comment/Comment";
 
 import { useToast } from "@/hooks/useToast";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 
 import { useModalStore } from "@/states/modalStore";
 import { useAuthStore } from "@/states/authStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import { usePostsDetails } from "@/api/posts/getPostsId";
 import { deletePostsSave, putPostsSave } from "@/api/posts/putDeletePostsIdSave";
@@ -40,10 +39,9 @@ export default function PostDetail({ id }: PostDetailProps) {
 
   const { isLoggedIn, user_id } = useAuthStore();
   const { openModal } = useModalStore();
-  const { isMobile } = useDeviceStore();
 
   const { showToast } = useToast();
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   const [currentLikeCount, setCurrentLikeCount] = useState(0);
   const [isLiked, setIsLiked] = useState(false);

--- a/src/components/DatePicker/MonthPicker/index.tsx
+++ b/src/components/DatePicker/MonthPicker/index.tsx
@@ -1,15 +1,11 @@
 import { useState } from "react";
 
-import { isBefore, startOfMonth } from "date-fns";
-
 import Icon from "@/components/Asset/IconTemp";
 import Button from "@/components/Button/Button";
 import BottomSheet from "@/components/BottomSheet/BottomSheet";
 import MonthListContent from "@/components/DatePicker/MonthPicker/MonthListContent";
 
 import useDateNavigation from "@/hooks/useDateNavigation";
-import { useIsMobile } from "@/hooks/useIsMobile";
-
 import { useDeviceStore } from "@/states/deviceStore";
 
 import { formattedDate } from "@/utils/formatDate";
@@ -26,8 +22,7 @@ function MonthPicker({ selectedDate, onDateChange }: MonthPickerProps) {
   const { currentDate, onPrevMonth, onNextMonth, isPrevDisabled, isNextDisabled } =
     useDateNavigation(selectedDate, onDateChange);
 
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   const handleToggleMonthList = () => {
     setIsOpen(!isOpen);

--- a/src/components/Detail/Author/Author.tsx
+++ b/src/components/Detail/Author/Author.tsx
@@ -28,7 +28,7 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
   const [isFollowing, setIsFollowing] = useState(false);
   const [followerCount, setFollowerCount] = useState(0);
   const { showToast } = useToast();
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { pathname } = useRouter();
 
   useEffect(() => {

--- a/src/components/Detail/Comment/Comment.tsx
+++ b/src/components/Detail/Comment/Comment.tsx
@@ -15,10 +15,10 @@ import { deleteComments } from "@/api/feeds-comments/deleteFeedComment";
 import { deleteCommentLike, putCommentLike } from "@/api/feeds-comments/putDeleteCommentsLike";
 
 import { useAuthStore } from "@/states/authStore";
-import { useDeviceStore } from "@/states/deviceStore";
 import { useModalStore } from "@/states/modalStore";
 
 import { useToast } from "@/hooks/useToast";
+import { useDeviceStore } from "@/states/deviceStore";
 
 import Loader from "@/components/Layout/Loader/Loader";
 import Dropdown from "@/components/Dropdown/Dropdown";
@@ -49,7 +49,7 @@ export default function Comment({ feedId, feedWriterId, isFollowingPage }: Comme
   const { mutateAsync: postComment, isPending: isPostCommentLoading } = usePostFeedsComments();
   const [activeParentReplyId, setActiveParentReplyId] = useState<string | null>(null);
   const [activeChildReplyId, setActiveChildReplyId] = useState<string | null>(null);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { pathname } = useRouter();
 
   useEffect(() => {

--- a/src/components/Detail/Comment/CommentInput/CommentInput.tsx
+++ b/src/components/Detail/Comment/CommentInput/CommentInput.tsx
@@ -21,7 +21,7 @@ export default function CommentInput({
   showToast,
   onCommentSubmitSuccess,
 }: CommentInputProps) {
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const [comment, setComment] = useState("");
   const { mutateAsync: postComment, isPending: isPostCommentPending } = usePostFeedsComments();
 

--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -26,7 +26,6 @@ import { deleteSave, putSave } from "@/api/feeds/putDeleteFeedsIdSave";
 import Comment from "./Comment/Comment";
 import NewFeed from "../Layout/NewFeed/NewFeed";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import { useAuthRefresh } from "@/hooks/useAuthRefresh";
 
@@ -46,8 +45,7 @@ export default function Detail({ id }: DetailProps) {
   const sectionRef = usePreventRightClick<HTMLElement>();
   const router = useRouter();
   const openModal = useModalStore((state) => state.openModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
   usePreventScroll(!!overlayImage);
 
   const { pathname } = useRouter();

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useEffect } from "react";
 import styles from "./Dropdown.module.scss";
 import { DropdownProps } from "./Dropdown.types";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 export default function Dropdown({
   menuItems,
@@ -13,10 +12,7 @@ export default function Dropdown({
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   const toggleDropdown = (newState: boolean) => {
     setIsOpen(newState);

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
@@ -24,7 +24,6 @@ import Comment from "@/components/Detail/Comment/Comment";
 import { useGetFeedsComments } from "@/api/feeds-comments/getFeedComments";
 import { useMyData } from "@/api/users/getMe";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { FollowingFeedsResponse } from "@/api/feeds/getFeedsFollowing";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
@@ -54,12 +53,11 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
   });
   const [isContentTooLong, setIsContentTooLong] = useState(false);
   const contentRef = useRef<HTMLParagraphElement | null>(null);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const imgRef = usePreventRightClick<HTMLImageElement>();
   const divRef = usePreventRightClick<HTMLDivElement>();
   const sectionRef = usePreventRightClick<HTMLElement>();
 
-  useIsMobile();
   usePreventScroll(!!overlayImage);
 
   useEffect(() => {

--- a/src/components/Layout/Header/Default/DefaultHeader.tsx
+++ b/src/components/Layout/Header/Default/DefaultHeader.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import { useMyData } from "@/api/users/getMe";
 
 import { useAuthStore } from "@/states/authStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import IconComponent from "@/components/Asset/Icon";
 import Button from "@/components/Button/Button";
@@ -14,7 +13,7 @@ import Notifications from "@/components/Notifications/Notifications";
 import Login from "@/components/Modal/Login/Login";
 import SideMenu from "@/components/Layout/SideMenu/SideMenu";
 
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import { usePreventScroll } from "@/hooks/usePreventScroll";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
 import { useModal } from "@/hooks/useModal";
@@ -34,10 +33,9 @@ export default function DefaultHeader() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const { isLoggedIn, setAccessToken, setIsLoggedIn, setUserId, isAuthReady } = useAuthStore();
-  const isMobile = useDeviceStore((state) => state.isMobile);
 
   const { openModal } = useModal();
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
   usePreventScroll(isMenuOpen || (isMobile && showNotifications));
   useOnClickOutside(notificationRef, () => setShowNotifications(false));
   useOnClickOutside(dropdownRef, () => setIsDropdownOpen(false));

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -3,14 +3,13 @@ import { useRouter } from "next/router";
 
 import { useMyData } from "@/api/users/getMe";
 
-import { useDeviceStore } from "@/states/deviceStore";
 import { useAuthStore } from "@/states/authStore";
 
 import IconComponent from "@/components/Asset/Icon";
 import Header from "@/components/Layout/Header/Header";
 import Sidebar from "@/components/Layout/Sidebar/Sidebar";
 
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 
 import type { HeaderProps } from "@/components/Layout/Header/types/Header.types";
 import type { LayoutProps } from "@/components/Layout/Layout.types";
@@ -22,9 +21,7 @@ export default function Layout({ children }: LayoutProps) {
 
   const [isScrollAbove, setIsScrollAbove] = useState(false);
 
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   const { setIsLoggedIn, setAccessToken, setUserId, setIsAuthReady } = useAuthStore();
   const { refetch: fetchMyData } = useMyData();

--- a/src/components/Layout/Ranking/Ranking.tsx
+++ b/src/components/Layout/Ranking/Ranking.tsx
@@ -5,8 +5,6 @@ import { Swiper, SwiperRef, SwiperSlide } from "swiper/react";
 
 import { useRankings } from "@/api/feeds/getRankings";
 
-import { useDeviceStore } from "@/states/deviceStore";
-
 import SquareCard from "@/components/Layout/SquareCard/SquareCard";
 import Title from "@/components/Layout/Title/Title";
 import IconComponent from "@/components/Asset/Icon";

--- a/src/components/Layout/SideMenu/SideMenu.tsx
+++ b/src/components/Layout/SideMenu/SideMenu.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { useMyData } from "@/api/users/getMe";
 
 import { useAuthStore } from "@/states/authStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import IconComponent from "@/components/Asset/Icon";
 import Button from "@/components/Button/Button";
@@ -14,6 +13,7 @@ import FooterSection from "@/components/Layout/FooterSection/FooterSection";
 import Login from "@/components/Modal/Login/Login";
 
 import { useModal } from "@/hooks/useModal";
+import { useDeviceStore } from "@/states/deviceStore";
 
 import axiosInstance from "@/constants/baseurl";
 
@@ -36,7 +36,7 @@ const SideMenu = ({ isOpen, onClose }: SideMenuProps) => {
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   const setUserId = useAuthStore((state) => state.setUserId);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
 
   const isNavPage = ["/", "/ranking", "/board", "/following"].includes(router.pathname);
 

--- a/src/components/Modal/AlbumEdit/AlbumEdit.tsx
+++ b/src/components/Modal/AlbumEdit/AlbumEdit.tsx
@@ -9,17 +9,17 @@ import { deleteAlbums } from "@/api/albums/deleteAlbums";
 import { putAlbumsOrder } from "@/api/albums/putAlbumsOrder";
 import { useMyAlbums } from "@/api/me/getMyAlbums";
 import { useToast } from "@/hooks/useToast";
-import { useDeviceStore } from "@/states/deviceStore";
 import { useModalStore } from "@/states/modalStore";
 import { DragDropContext, Droppable, Draggable, DropResult } from "@hello-pangea/dnd";
 import router from "next/router";
 import axios from "axios";
 import { AlbumBaseResponse } from "@/api/me/getMyAlbums";
+import { useDeviceStore } from "@/states/deviceStore";
 
 export default function AlbumEdit() {
   const { data, isLoading, isError, refetch } = useMyAlbums();
   const closeModal = useModalStore((state) => state.closeModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { showToast } = useToast();
   const albumsRef = useRef<AlbumBaseResponse[]>([]);
   const [albums, setAlbums] = useState<AlbumBaseResponse[]>([]);

--- a/src/components/Modal/AlbumMove/AlbumMove.tsx
+++ b/src/components/Modal/AlbumMove/AlbumMove.tsx
@@ -5,17 +5,17 @@ import Button from "@/components/Button/Button";
 import IconComponent from "@/components/Asset/Icon";
 import { useToast } from "@/hooks/useToast";
 import { useMyAlbums } from "@/api/me/getMyAlbums";
-import { useDeviceStore } from "@/states/deviceStore";
 import { useModalStore } from "@/states/modalStore";
 import { putFeedsInAlbums } from "@/api/albums/putFeedsInAlbums";
 import { putFeedsNull } from "@/api/albums/putFeedsNull";
 import { useRouter } from "next/router";
+import { useDeviceStore } from "@/states/deviceStore";
 
 export default function AlbumMove() {
   const { data, refetch } = useMyAlbums();
   const albums = Array.isArray(data) ? data : [];
   const { showToast } = useToast();
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const closeModal = useModalStore((state) => state.closeModal);
   const modalData = useModalStore((state) => state.data);
   const router = useRouter();

--- a/src/components/Modal/AlbumSelect/AlbumSelect.tsx
+++ b/src/components/Modal/AlbumSelect/AlbumSelect.tsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
 import { useMyAlbums } from "@/api/me/getMyAlbums";
-import { useDeviceStore } from "@/states/deviceStore";
 import { useModalStore } from "@/states/modalStore";
 import styles from "./AlbumSelect.module.scss";
 import Button from "@/components/Button/Button";
 import IconComponent from "@/components/Asset/Icon";
+import { useDeviceStore } from "@/states/deviceStore";
 
 export default function AlbumSelect() {
   const { data: albums = [] } = useMyAlbums();
   const modalData = useModalStore((state) => state.data);
   const [selectedId, setSelectedId] = useState<string | null>(modalData?.selectedAlbumId ?? null);
   const closeModal = useModalStore((state) => state.closeModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
 
   const handleSubmit = () => {
     if (modalData?.onSelect) {

--- a/src/components/Modal/Background/Background.tsx
+++ b/src/components/Modal/Background/Background.tsx
@@ -9,7 +9,6 @@ import { postPresignedUrl } from "@/api/aws/postPresigned";
 import { putBackgroundImage } from "@/api/users/putMeImage";
 import IconComponent from "@/components/Asset/Icon";
 import { useMutation } from "@tanstack/react-query";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMyData } from "@/api/users/getMe";
 
 interface BackgroundProps {
@@ -20,7 +19,6 @@ interface BackgroundProps {
 
 export default function Background({ imageSrc, file, onUploadSuccess }: BackgroundProps) {
   const { refetch } = useMyData();
-  useIsMobile();
   const closeModal = useModalStore((state) => state.closeModal);
   const { showToast } = useToast();
   const [crop, setCrop] = useState<PercentCrop>({

--- a/src/components/Modal/Follow/Follow.tsx
+++ b/src/components/Modal/Follow/Follow.tsx
@@ -10,7 +10,6 @@ import { deleteFollow } from "@/api/users/deleteIdFollow";
 import { useToast } from "@/hooks/useToast";
 import { FollowProps } from "./Follow.types";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 export default function Follow({ initialTab }: FollowProps) {
   const [activeTab, setActiveTab] = useState<"follower" | "following">(initialTab);
@@ -21,8 +20,7 @@ export default function Follow({ initialTab }: FollowProps) {
   const [isFetchingData, setIsFetchingData] = useState(false);
   const route = useRouter();
   const { showToast } = useToast();
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   const {
     data: followerData,

--- a/src/components/Modal/Like/Like.tsx
+++ b/src/components/Modal/Like/Like.tsx
@@ -5,14 +5,12 @@ import { useModalStore } from "@/states/modalStore";
 import { useFeedsLike } from "@/api/feeds/getFeedsIdLike";
 import Loader from "@/components/Layout/Loader/Loader";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 export default function Like() {
   const closeModal = useModalStore((state) => state.closeModal);
   const route = useRouter();
   const { data, isLoading } = useFeedsLike({ id: String(route.query.id) });
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   const handleClickUser = (url: string) => {
     route.push(`${url}`);

--- a/src/components/Modal/ProfileEdit/ProfileEdit.tsx
+++ b/src/components/Modal/ProfileEdit/ProfileEdit.tsx
@@ -9,7 +9,6 @@ import { useMyData } from "@/api/users/getMe";
 import { UpdateProfileConflictResponse, putMyInfo } from "@/api/users/putMe";
 
 import { useModalStore } from "@/states/modalStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import TextField from "@/components/TextField/TextField";
 import IconComponent from "@/components/Asset/Icon";
@@ -18,7 +17,7 @@ import Loader from "@/components/Layout/Loader/Loader";
 import { SelectBox } from "@/components/SelectBox/SelectBox";
 
 import { useToast } from "@/hooks/useToast";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 
 import { isValidProfileIdFormat, isForbiddenProfileId } from "@/utils/isValidProfileId";
@@ -54,8 +53,7 @@ export default function ProfileEdit() {
   const closeModal = useModalStore((s) => s.closeModal);
   const { restoreScrollPosition } = useScrollRestoration("profileEdit-scroll");
   const { showToast } = useToast();
-  const isMobile = useDeviceStore((s) => s.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   useEffect(() => {
     if (myData) {

--- a/src/components/Modal/ProfileLink/ProfileLink.tsx
+++ b/src/components/Modal/ProfileLink/ProfileLink.tsx
@@ -1,6 +1,5 @@
-import { useDeviceStore } from "@/states/deviceStore";
 import styles from "./ProfileLink.module.scss";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import IconComponent from "@/components/Asset/Icon";
 import { useUserDataByUrl } from "@/api/users/getId";
 import { useRouter } from "next/router";
@@ -8,10 +7,9 @@ import { useClipboard } from "@/utils/copyToClipboard";
 
 export default function ProfileLink() {
   const { copyToClipboard } = useClipboard();
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { query } = useRouter();
   const { data: userData } = useUserDataByUrl(query.url as string);
-  useIsMobile();
 
   const getIconName = (linkName: string) => {
     if (linkName === "인스타그램") return "linkInstagram";

--- a/src/components/Modal/Upload/Upload.tsx
+++ b/src/components/Modal/Upload/Upload.tsx
@@ -1,13 +1,11 @@
 import { useRouter } from "next/router";
 
-import { useDeviceStore } from "@/states/deviceStore";
-
 import Button from "@/components/Button/Button";
 import { serviceUrl } from "@/constants/serviceurl";
 import IconComponent from "@/components/Asset/Icon";
 
 import { useToast } from "@/hooks/useToast";
-
+import { useDeviceStore } from "@/states/deviceStore";
 import type { UploadModalProps } from "@/components/Modal/Upload/Upload.types";
 
 import styles from "@/components/Modal/Upload/Upload.module.scss";
@@ -17,7 +15,7 @@ export default function UploadModal({ feedId, title, image, close }: UploadModal
   const router = useRouter();
 
   const url = `${serviceUrl}feeds/${feedId}`;
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
 
   const copyToClipboard = async () => {
     try {

--- a/src/components/Notifications/Noti/Noti.tsx
+++ b/src/components/Notifications/Noti/Noti.tsx
@@ -14,7 +14,7 @@ import { imageUrl as imagePrefix } from "@/constants/imageUrl";
 export default function Noti({ notification, onClose, onRefetch }: NotiProps) {
   const { showToast } = useToast();
   const router = useRouter();
-  const isTablet = useDeviceStore((state) => state.isTablet);
+  const { isTablet } = useDeviceStore();
 
   const renderMessage = () => {
     return notification?.message || "";

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -8,7 +8,6 @@ import { deleteNotifications } from "@/api/notifications/deleteNotifications";
 import { putNotifications } from "@/api/notifications/putNotifications";
 import { getSubscribe, putSubscribe, SubscriptionType } from "@/api/users/subscribe";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 
 const ALL_SUBSCRIPTION_TYPES: SubscriptionType[] = [
   "FOLLOW",
@@ -160,8 +159,7 @@ export default function Notifications({ onClose }: NotificationsProps) {
   const { data = [], refetch } = useGetNotifications();
   const [isOpen, setIsOpen] = useState(false);
   const [subscriptions, setSubscriptions] = useState<SubscriptionType[]>([]);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   useEffect(() => {
     const fetchSubscriptions = async () => {

--- a/src/components/ProfilePage/FeedAlbumEditor/FeedAlbumEditor.tsx
+++ b/src/components/ProfilePage/FeedAlbumEditor/FeedAlbumEditor.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
+import { useRouter } from "next/router";
+
+import { ModalState, ModalType, useModalStore } from "@/states/modalStore";
+
 import ProfileCard from "@/components/Layout/ProfileCard/ProfileCard";
 import Button from "@/components/Button/Button";
-import { ModalState, ModalType, useModalStore } from "@/states/modalStore";
-import { useRouter } from "next/router";
+import Icon from "@/components/Asset/IconTemp";
+
 import { useDeviceStore } from "@/states/deviceStore";
 
 import styles from "@/components/ProfilePage/FeedAlbumEditor/FeedAlbumEditor.module.scss";
-import Icon from "@/components/Asset/IconTemp";
 
 interface Feed {
   id: string;
@@ -41,7 +44,7 @@ export default function FeedAlbumEditor({
 }: FeedAlbumEditorProps) {
   const [selectedCards, setSelectedCards] = useState<string[]>([]);
   const openModal = useModalStore((state) => state.openModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const router = useRouter();
   const currentAlbum = activeAlbum ? albums.find((album) => album.id === activeAlbum) : null;
   const displayName = currentAlbum ? currentAlbum.name : "전체";

--- a/src/components/ProfilePage/Profile/Profile.tsx
+++ b/src/components/ProfilePage/Profile/Profile.tsx
@@ -3,7 +3,6 @@ import router, { useRouter } from "next/router";
 
 import { useAuthStore } from "@/states/authStore";
 import { useModalStore } from "@/states/modalStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import { useMyData } from "@/api/users/getMe";
 import { useUserDataByUrl } from "@/api/users/getId";
@@ -15,7 +14,7 @@ import ProfileImage from "@/components/ProfilePage/Profile/ProfileImage/ProfileI
 import ProfileDetails from "@/components/ProfilePage/Profile/ProfileDetails/ProfileDetails";
 
 import { useToast } from "@/hooks/useToast";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 import { useFollow } from "@/hooks/useFollow";
 import { useCoverImage } from "@/hooks/useCoverImage";
 import { useProfileImage } from "@/hooks/useProfileImage";
@@ -36,8 +35,7 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
   const [profileImage, setProfileImage] = useState<string>("");
   const [coverImage, setCoverImage] = useState<string>("");
   const { showToast } = useToast();
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
   const { handleFollowClick, handleUnfollowClick } = useFollow(id, refetchUserData);
   const { handleAddCover, handleDeleteImage } = useCoverImage(
     refetchUserData,

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -9,16 +9,15 @@ import { ProfilePageProps } from "./ProfilePage.types";
 import ProfileCard from "../Layout/ProfileCard/ProfileCard";
 import Dropdown from "../Dropdown/Dropdown";
 import Button from "../Button/Button";
-import IconComponent from "../Asset/Icon";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import AllCard from "../Board/BoardAll/AllCard/AllCard";
 import Category from "./Profile/CategoryBar/Category/Category";
-import { useDeviceStore } from "@/states/deviceStore";
 import FeedAlbumEditor from "./FeedAlbumEditor/FeedAlbumEditor";
 import { useDragScroll } from "@/hooks/useDragScroll";
 import Icon from "@/components/Asset/IconTemp";
 import Pagination from "@/components/Pagination";
+import { useDeviceStore } from "@/states/deviceStore";
 
 type SortOption = "latest" | "like" | "oldest";
 
@@ -32,7 +31,7 @@ const PAGE_SIZE = 12;
 
 export default function ProfilePage({ isMyProfile, id, url }: ProfilePageProps) {
   const openModal = useModalStore((state) => state.openModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const [sortBy, setSortBy] = useState<SortOption>("latest");
   const [indicatorStyle, setIndicatorStyle] = useState({ width: 0, left: 0 });
   const feedsTabRef = useRef<HTMLDivElement>(null);

--- a/src/components/RankingPage/PopularTag/index.tsx
+++ b/src/components/RankingPage/PopularTag/index.tsx
@@ -5,18 +5,15 @@ import Loader from "@/components/Layout/Loader/Loader";
 import Tag from "./Tag/Tag";
 import Link from "next/link";
 import { useCallback, useEffect, useRef } from "react";
+
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 
 export default function PopularTag() {
   const { data, isLoading } = useTagsPopular();
   const containerRef = useRef<HTMLDivElement>(null);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   // 가로 스크롤 시 세로 스크롤 막기
   const handleWheel = useCallback((e: WheelEvent) => {

--- a/src/components/RankingPage/PopularUser/index.tsx
+++ b/src/components/RankingPage/PopularUser/index.tsx
@@ -20,8 +20,7 @@ export default function PopularUser() {
   const [randomUsers, setRandomUsers] = useState<PopularUserResponse[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
   const divRef = usePreventRightClick<HTMLDivElement>();
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
+  const { isMobile, isTablet } = useDeviceStore();
 
   // 가로 스크롤 시 세로 스크롤 막기
   const handleWheel = useCallback((e: WheelEvent) => {

--- a/src/components/SearchPage/Feed/SearchCard/SearchCard.tsx
+++ b/src/components/SearchPage/Feed/SearchCard/SearchCard.tsx
@@ -8,8 +8,8 @@ import { deleteLike, putLike } from "@/api/feeds/putDeleteFeedsLike";
 import { SearchCardProps } from "./SearchCard.types";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import { SearchHighlightContext } from "@/pages/search";
-import "swiper/css";
 import { useDeviceStore } from "@/states/deviceStore";
+import "swiper/css";
 
 export default function SearchCard({
   id,
@@ -25,7 +25,7 @@ export default function SearchCard({
   const [isLiked, setIsLiked] = useState(isLike);
   const [currentLikeCount, setCurrentLikeCount] = useState(likeCount);
   const imgRef = usePreventRightClick<HTMLImageElement>();
-  const isMobile = useDeviceStore((state) => state.isMobile);
+  const { isMobile } = useDeviceStore();
   const { highlight } = useContext(SearchHighlightContext);
 
   const handleLikeClick = async (e: React.MouseEvent) => {

--- a/src/components/SearchPage/SearchPage.tsx
+++ b/src/components/SearchPage/SearchPage.tsx
@@ -8,7 +8,6 @@ import SearchFeed from "./Feed/SearchFeed/SearchFeed";
 import SearchAuthor from "./User/SearchAuthor/SearchAuthor";
 import SearchPost from "./Post/SearchPost/SearchPost";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { FreeMode } from "swiper/modules";
 import "swiper/css";
@@ -20,8 +19,7 @@ export default function SearchPage() {
   const { data: popularData } = useTagsPopular();
   const router = useRouter();
   const { tab } = router.query;
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   useEffect(() => {
     const keyword = router.query.keyword as string | undefined;

--- a/src/components/SearchPage/User/SearchProfile/SearchProfile.tsx
+++ b/src/components/SearchPage/User/SearchProfile/SearchProfile.tsx
@@ -10,7 +10,6 @@ import { putFollow } from "@/api/users/putIdFollow";
 import { useToast } from "@/hooks/useToast";
 import Button from "@/components/Button/Button";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { SearchHighlightContext } from "@/pages/search";
 
 export default function SearchProfile({
@@ -28,9 +27,7 @@ export default function SearchProfile({
   const { showToast } = useToast();
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
   const { highlight } = useContext(SearchHighlightContext);
 
   const handleFollowClick = async () => {

--- a/src/components/Upload/DraggableImage/DraggableImage.tsx
+++ b/src/components/Upload/DraggableImage/DraggableImage.tsx
@@ -3,7 +3,6 @@ import { DraggableImageProps } from "./DraggableImage.types";
 import styles from "./DraggableImage.module.scss";
 import { useState } from "react";
 import { useDeviceStore } from "@/states/deviceStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import IconComponent from "@/components/Asset/Icon";
 
 export default function DraggableImage({
@@ -14,9 +13,7 @@ export default function DraggableImage({
   isThumbnail,
   onThumbnailSelect,
 }: DraggableImageProps) {
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
-  const isTablet = useDeviceStore((state) => state.isTablet);
+  const { isMobile, isTablet } = useDeviceStore();
   const [isLoading, setIsLoading] = useState(true);
 
   const handleImageLoad = () => {

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -11,14 +11,13 @@ import DraggableImage from "@/components/Upload/DraggableImage/DraggableImage";
 import Chip from "@/components/Chip/Chip";
 
 import { useModalStore } from "@/states/modalStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import { CreateFeedRequest } from "@/api/feeds/postFeeds";
 
 import { FeedFormProps } from "@/components/Upload/FeedForm/FeedForm.types";
 
 import { useToast } from "@/hooks/useToast";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useDeviceStore } from "@/states/deviceStore";
 
 import { removeUrlPrefix } from "@/utils/removeUrlPrefix";
 
@@ -48,10 +47,7 @@ export default function FeedForm({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
-
-  useIsMobile();
+  const { isMobile, isTablet } = useDeviceStore();
 
   const resetUnsavedChanges = () => {
     hasUnsavedChangesRef.current = false;

--- a/src/hooks/useCoverImage.ts
+++ b/src/hooks/useCoverImage.ts
@@ -6,12 +6,11 @@ import { putBackgroundImage } from "@/api/users/putMeImage";
 import { deleteMyBackgroundImage } from "@/api/users/deleteMeImage";
 
 import { useModalStore } from "@/states/modalStore";
-import { useDeviceStore } from "@/states/deviceStore";
 
 import type { UserProfileResponse as UserData } from "@grimity/dto";
 
 import { useToast } from "@/hooks/useToast";
-
+import { useDeviceStore } from "@/states/deviceStore";
 import { convertToWebP } from "@/utils/imageConverter";
 
 export const useCoverImage = (
@@ -21,8 +20,7 @@ export const useCoverImage = (
 ) => {
   const { showToast } = useToast();
   const openModal = useModalStore((state) => state.openModal);
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  const isTablet = useDeviceStore((state) => state.isTablet);
+  const { isMobile, isTablet } = useDeviceStore();
 
   const { mutate: updateBackgroundImage } = useMutation({
     mutationFn: (imageName: string) => putBackgroundImage(imageName),

--- a/src/hooks/useInitializeDevice.ts
+++ b/src/hooks/useInitializeDevice.ts
@@ -1,23 +1,22 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { useDeviceStore } from "@/states/deviceStore";
 
-export const useIsMobile = () => {
-  useEffect(() => {
-    const setIsMobile = useDeviceStore.getState().setIsMobile;
-    const setIsTablet = useDeviceStore.getState().setIsTablet;
+export const useInitializeDevice = () => {
+  const { setDevice } = useDeviceStore();
 
+  useLayoutEffect(() => {
     const mobileQuery = window.matchMedia("(max-width: 767px)");
     const tabletQuery = window.matchMedia("(min-width: 768px) and (max-width: 1024px)");
 
     const handleResize = () => {
-      setIsMobile(mobileQuery.matches);
-      setIsTablet(tabletQuery.matches);
+      setDevice({
+        isMobile: mobileQuery.matches,
+        isTablet: tabletQuery.matches,
+      });
     };
 
-    // 초기 설정
-    handleResize();
+    handleResize(); // 초기 렌더링 시 실행
 
-    // 이벤트 리스너 등록
     mobileQuery.addEventListener("change", handleResize);
     tabletQuery.addEventListener("change", handleResize);
 
@@ -25,5 +24,5 @@ export const useIsMobile = () => {
       mobileQuery.removeEventListener("change", handleResize);
       tabletQuery.removeEventListener("change", handleResize);
     };
-  }, []);
+  }, [setDevice]);
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,8 @@ import Modal from "@/components/Modal/Modal";
 import Toast from "@/components/Toast/Toast";
 import ModalProvider from "@/components/Modal/Provider";
 
+import { useInitializeDevice } from "@/hooks/useInitializeDevice";
+
 import "@/styles/globals.scss";
 import "@/styles/reset.css";
 import "swiper/css";
@@ -18,6 +20,8 @@ import "swiper/css/navigation";
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
+  useInitializeDevice();
+
   return (
     <>
       <QueryClientProvider client={queryClient}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,6 @@ import Ranking from "@/components/Layout/Ranking/Ranking";
 import NewFeed from "@/components/Layout/NewFeed/NewFeed";
 import MainBoard from "@/components/Layout/MainBoard/MainBoard";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { useDeviceStore } from "@/states/deviceStore";
 
 import IconComponent from "@/components/Asset/Icon";
@@ -19,8 +18,7 @@ export default function Home() {
   const [OGTitle] = useState("그리미티");
   const [OGUrl, setOGUrl] = useState(serviceUrl);
   const { restoreScrollPosition } = useScrollRestoration("home-scroll");
-  const isMobile = useDeviceStore((state) => state.isMobile);
-  useIsMobile();
+  const { isMobile } = useDeviceStore();
 
   useEffect(() => {
     setOGUrl(`${serviceUrl}/${router.asPath}`);

--- a/src/states/deviceStore.ts
+++ b/src/states/deviceStore.ts
@@ -3,13 +3,11 @@ import { create } from "zustand";
 interface DeviceState {
   isMobile: boolean;
   isTablet: boolean;
-  setIsMobile: (value: boolean) => void;
-  setIsTablet: (value: boolean) => void;
+  setDevice: (device: { isMobile: boolean; isTablet: boolean }) => void;
 }
 
 export const useDeviceStore = create<DeviceState>((set) => ({
   isMobile: false,
   isTablet: false,
-  setIsMobile: (value) => set({ isMobile: value }),
-  setIsTablet: (value) => set({ isTablet: value }),
+  setDevice: (device) => set(device),
 }));


### PR DESCRIPTION
### 🔎 작업 내용
- 기존에는 반응형 UI 구현을 위해 각 컴포넌트에서 개별적으로 `useIsMobile`을 호출했습니다. 
  - 이 방식은 해당 훅을 사용하는 컴포넌트 수만큼 `matchMedia` 이벤트 리스너를 중복으로 생성하여 성능 저하의 우려가 있었습니다.
- 앱 전역에서 단 하나의 이벤트 리스너만 사용하도록 구조를 개선했습니다. 
  - `_app.tsx`에서 디바이스 크기 변경을 감지하여 전역 상태를 업데이트하고, 각 컴포넌트는 이 전역 상태(deviceStore)를 구독하여 사용하는 방식으로 변경했습니다.
