### PR TITLE
fix: 이용약관 및 개인정보처리방침 링크 수정

### DIFF
--- a/src/components/Layout/FooterSection/FooterSection.tsx
+++ b/src/components/Layout/FooterSection/FooterSection.tsx
@@ -92,7 +92,7 @@ function FooterSection({ onClose }: FooterSectionProps) {
       <div className={styles.subLinkWrapper}>
         <div className={styles.subLink}>
           <Link
-            href="https://nostalgic-patch-498.notion.site/1930ac6bf29881e9a3e4c405e7f49f2b?pvs=73"
+            href="https://term.grimity.com/term"
             target="_blank"
             rel="noopener noreferrer"
             onClick={onClose}
@@ -100,7 +100,7 @@ function FooterSection({ onClose }: FooterSectionProps) {
             이용약관
           </Link>
           <Link
-            href="https://nostalgic-patch-498.notion.site/1930ac6bf29881b9aa19ff623c69b8e6?pvs=74"
+            href="https://term.grimity.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
             onClick={onClose}

--- a/src/components/Layout/Header/Contact/Contact.tsx
+++ b/src/components/Layout/Header/Contact/Contact.tsx
@@ -63,7 +63,7 @@ export default function Contact({ onClose }: ContactProps) {
         <div className={styles.bar} />
         <section className={styles.footer}>
           <a
-            href="https://nostalgic-patch-498.notion.site/1930ac6bf29881b9aa19ff623c69b8e6?pvs=74"
+            href="https://term.grimity.com/privacy"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.subLink}
@@ -71,7 +71,7 @@ export default function Contact({ onClose }: ContactProps) {
             개인정보취급방침
           </a>
           <a
-            href="https://nostalgic-patch-498.notion.site/1930ac6bf29881e9a3e4c405e7f49f2b?pvs=73"
+            href="https://term.grimity.com/term"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.subLink}

--- a/src/components/Modal/Nickname/Nickname.tsx
+++ b/src/components/Modal/Nickname/Nickname.tsx
@@ -96,7 +96,7 @@ export default function Nickname() {
             </div>
             <span className={styles.text}>
               <a
-                href="https://nostalgic-patch-498.notion.site/1930ac6bf29881e9a3e4c405e7f49f2b?pvs=73"
+                href="https://term.grimity.com/term"
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.underline}
@@ -105,7 +105,7 @@ export default function Nickname() {
               </a>{" "}
               과{" "}
               <a
-                href="https://nostalgic-patch-498.notion.site/1930ac6bf29881b9aa19ff623c69b8e6?pvs=74"
+                href="https://term.grimity.com/privacy"
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.underline}


### PR DESCRIPTION
GCP 콘솔에서 뜨는 경고문구를 없애기 위해 이용약관 및 개인정보처리방침 링크를 자체 도메인에 물리도록 수정했습니다.

<img width="605" height="668" alt="image" src="https://github.com/user-attachments/assets/1277ce0e-6222-4c76-9cba-131a17f3b2fc" />
