### PR TITLE
[Design] em 태그 기울임꼴 스타일 추가

### DIFF
--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -111,6 +111,11 @@ section {
 body {
   line-height: 1;
 }
+
+em {
+  font-style: italic;
+}
+
 ol,
 ul {
   list-style: none;


### PR DESCRIPTION
### 🔎 작업 내용
- `reset`으로 인해 em 태그의 폰트 스타일인 기울임꼴이 사라져 다시 추가했습니다.

### 📸 스크린샷
**AS-IS**
<img width="1896" height="1700" alt="image" src="https://github.com/user-attachments/assets/1d2d819a-25f7-40d0-b23b-15a7d7514373" />

**TO-BE**
<img width="1840" height="1117" alt="image" src="https://github.com/user-attachments/assets/4124d718-b6f8-4461-bdd8-e77969a6658c" />
