### PR TITLE
[Fix] 에디터 링크 사용 시 절대경로로 적용되게 수정

### DIFF
--- a/src/components/Board/BoardWrite/PostForm/PostForm.tsx
+++ b/src/components/Board/BoardWrite/PostForm/PostForm.tsx
@@ -112,6 +112,8 @@ export default function PostForm({
                 indent: false,
                 indent_use_margin: true,
                 indent_size: 4,
+                relative_urls: false,
+                remove_script_host: false,
                 setup: (editor) => {
                   editor.on("keydown", (event) => {
                     if (event.key === "Tab") {


### PR DESCRIPTION
### 🔎 작업 내용
- 에디터에 그리미티 주소를 링크를 등록할 경우, 기본 설정으로 인해 상대경로로 저장되는 문제가 있었습니다. 모바일 환경에서는 상대경로가 정상적으로 동작하지 않아 절대경로가 필요했습니다.
- 이를 해결하기 위해 TinyMCE 설정에서 아래 두 옵션을 false로 수정했습니다.
```
{
  relative_urls: false,
  remove_script_host: false,
}
```
- [TinyMCE 공식문서](https://www.tiny.cloud/docs/tinymce/latest/url-handling)

### 📸 스크린샷
**AS-IS**
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/2be45de5-63a0-4d75-beef-5ac478ca67ad" />

**TO-BE**
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/7e445dba-8338-48d5-a556-36f6baf70654" />

### 📢 전달사항
- 이미 상대경로로 저장한 것은 유저가 직접 수정을 하지 않는 이상은 절대경로로 변경되지 않습니다.