### PR TITLE
[Fix] 앨범선택 - safearea 설정 구간 변경, 프로필 - 아이콘 색상 변경

### DIFF
--- a/src/components/Modal/AlbumSelect/AlbumSelect.module.scss
+++ b/src/components/Modal/AlbumSelect/AlbumSelect.module.scss
@@ -12,6 +12,7 @@
 
   @include Size("mobile") {
     overflow-y: auto;
+    padding-bottom: calc(30px + env(safe-area-inset-bottom));
   }
 
   .titleContainer {
@@ -135,10 +136,6 @@
     .cancleBtn,
     .submitBtn {
       flex: 1;
-    }
-
-    @include Size("mobile") {
-      padding-bottom: calc(16px + env(safe-area-inset-bottom));
     }
   }
 }

--- a/src/components/ProfilePage/Profile/ProfileImage/ProfileImage.module.scss
+++ b/src/components/ProfilePage/Profile/ProfileImage/ProfileImage.module.scss
@@ -10,6 +10,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  color: $gray70;
 }
 
 .profileImageContainer {

--- a/src/components/ProfilePage/ProfilePage.module.scss
+++ b/src/components/ProfilePage/ProfilePage.module.scss
@@ -107,6 +107,7 @@
         padding: 14px;
         background: none;
         border: 1px solid $gray30;
+        color: $gray70;
 
         svg {
           width: 18px;
@@ -159,6 +160,7 @@
         border: none;
         padding: 0;
         height: 40px;
+        color: $gray70;
 
         .label {
           @include Body1;

--- a/src/components/ProfilePage/ProfilePage.tsx
+++ b/src/components/ProfilePage/ProfilePage.tsx
@@ -48,12 +48,10 @@ export default function ProfilePage({ isMyProfile, id, url }: ProfilePageProps) 
   const categoryBarRef = useRef<HTMLDivElement>(null);
   useDragScroll(categoryBarRef as React.RefObject<HTMLElement>, { scrollSpeed: 2 });
   const [isEditMode, setIsEditMode] = useState(false);
-  const [selectedCards, setSelectedCards] = useState<string[]>([]);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
   const toggleEditMode = () => {
     setIsEditMode(!isEditMode);
-    setSelectedCards([]);
     refetch();
   };
 

--- a/src/pages/[url].tsx
+++ b/src/pages/[url].tsx
@@ -5,7 +5,6 @@ import { serviceUrl } from "@/constants/serviceurl";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 import { GetServerSideProps } from "next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { DEFAULT_THUMBNAIL } from "@/constants/imageUrl";
 
@@ -28,7 +27,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 export default function Profile({ data }: Props) {
-  const router = useRouter();
   const { data: myData } = useMyData();
   const { restoreScrollPosition } = useScrollRestoration("profile-scroll");
 


### PR DESCRIPTION
### 🔎 작업 내용
- 앨범선택: safearea 설정하는 구간을 변경했습니다. 
- 프로필: 모바일에서 아이콘 색상을 파란색에서 gray70으로 변경했습니다.


### 📸 스크린샷
#### 앨범선택
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/f99f0af5-fa1f-4d92-bfa3-f3c26c8a9b85" />

#### 프로필
**AS-IS**
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/2be26a61-9313-4e34-9c6f-5d367d0f7b59" />

**TO-BE**
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/50d3b527-b2a0-4fc1-9284-fca90e9dcb42" />


### :loudspeaker: 전달사항
- 앨범선택은 시뮬레이터로 돌린거라 배포하고 실제 폰으로 테스트가 필요합니다.