### PR TITLE
[Fix] 모달 - 반응형 높이 설정

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -14,6 +14,8 @@ import { useDeviceStore } from "@/states/deviceStore";
 import type { HeaderProps } from "@/components/Layout/Header/types/Header.types";
 import type { LayoutProps } from "@/components/Layout/Layout.types";
 
+import { setDocumentViewportHeight } from "@/utils/viewport";
+
 import styles from "@/components/Layout/Layout.module.scss";
 
 export default function Layout({ children }: LayoutProps) {
@@ -38,6 +40,14 @@ export default function Layout({ children }: LayoutProps) {
   } else {
     headerVariant = "default";
   }
+
+  // 모바일 높이 설정
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setDocumentViewportHeight();
+      window.addEventListener("resize", setDocumentViewportHeight);
+    }
+  }, []);
 
   useEffect(() => {
     const initializeAuth = async () => {

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -137,7 +137,7 @@
 .fill {
   @include Size("mobile") {
     width: 100%;
-    height: calc(100vh - 60px);
+    height: calc($full-height - 60px);
     background: $gray0;
     padding: 16px;
     position: fixed;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import type { AppProps } from "next/app";
 import Script from "next/script";
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,6 +4,11 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1.0, 
+    user-scalable=0"
+        />
         <link rel="icon" href="/favicon/favicon-16x16.png" />
         <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png" />
         <link

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -252,6 +252,8 @@ $sidebar-width-tablet: 80px;
 $max-width-container: 1280px;
 $max-width-content: 780px;
 
+$full-height: calc(var(--vh, 1vh) * 100);
+
 @mixin Size($device) {
   @media (min-width: map.get($min-breakpoints, $device)) and (max-width: map.get($max-breakpoints, $device)) {
     @content;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -2,6 +2,10 @@
    License: none (public domain)
 */
 
+:root {
+  --vh: 100%;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -108,6 +112,13 @@ nav,
 section {
   display: block;
 }
+
+html,
+body {
+  height: 100vh;
+  height: var(--vh);
+}
+
 body {
   line-height: 1;
 }

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -1,0 +1,3 @@
+export const setDocumentViewportHeight = (): void => {
+  document.documentElement.style.setProperty("--vh", `${window.innerHeight * 0.01}px`);
+};


### PR DESCRIPTION
### 이슈
- #145

### 🔎 작업 내용
- 모바일에서 주소창으로 인해 100vh가 제대로 설정되지 않아 `window.innerHeight`와 resize를 이용하여 현재 높이를 계산하여 보이도록 했습니다.
- 모바일에서 인풋 선택 시 확대되는 이슈가 있어 이를 수정했습니다.

### 📸 스크린샷

<img width="514" height="1000" alt="스크린샷 2025-09-25 오후 10 12 14" src="https://github.com/user-attachments/assets/3ad9dd7b-dac8-461e-9f20-5884727ec955" />
