### PR TITLE
[Fix] 채팅방 스크롤 및 무한스크롤 로직 수정

### DIFF
--- a/src/components/ChatRoom/ChatRoom.module.scss
+++ b/src/components/ChatRoom/ChatRoom.module.scss
@@ -2,12 +2,14 @@
 
 .container {
   width: 100%;
-  height: calc($full-height - $header-height);
+  min-height: calc($full-height - $header-height);
   display: flex;
   flex-direction: column;
+  flex-basis: 0;
+  flex-grow: 1;
 
   @include Size("mobile") {
-    height: $full-height;
+    min-height: $full-height;
   }
 }
 

--- a/src/components/ChatRoom/MessageList/MessageList.module.scss
+++ b/src/components/ChatRoom/MessageList/MessageList.module.scss
@@ -4,9 +4,12 @@ $chat-room-height: 60px;
 $footer-height: 84px;
 
 .messagesContainer {
-  flex: 1;
-  min-height: 0;
-  max-height: calc($full-height - $header-height - $chat-room-height - $footer-height);
+  overflow-x: hidden;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  flex-basis: 0;
+  flex-grow: 1;
   padding: 20px 40px;
   overflow-y: auto;
   display: flex;
@@ -16,7 +19,6 @@ $footer-height: 84px;
 
   @include Size("mobile") {
     padding: 10px 16px;
-    max-height: calc($full-height - $chat-room-height - $footer-height);
   }
 
   .loadingContainer {

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect } from "react";
 
 import { useGetChatMessages } from "@/api/chat-messages/getChatMessages";
 import { useChatStore } from "@/states/chatStore";
-import { useToast } from "@/hooks/useToast";
 
 import { convertApiMessageToChatMessage } from "@/utils/messageConverter";
 
@@ -12,15 +11,7 @@ interface UseChatMessagesOptions {
 }
 
 export const useChatMessages = ({ chatId, containerRef }: UseChatMessagesOptions) => {
-  const { showToast } = useToast();
-  const {
-    chatRooms,
-    setIsLoadingMore,
-    addOlderMessages,
-    setNextCursor,
-    setHasNextPage,
-    initializeWithMessages,
-  } = useChatStore();
+  const { chatRooms, addOlderMessages, setNextCursor, setHasNextPage } = useChatStore();
 
   const currentRoom = chatRooms[chatId];
 
@@ -29,78 +20,42 @@ export const useChatMessages = ({ chatId, containerRef }: UseChatMessagesOptions
     { enabled: !!chatId && typeof chatId === "string" },
   );
 
-  const loadMoreMessages = useCallback(async () => {
-    if (!hasNextPage || isFetchingNextPage) return;
-
-    const container = containerRef.current;
-    if (!container) return;
-
-    const previousScrollHeight = container.scrollHeight;
-    const previousScrollTop = container.scrollTop;
-
-    setIsLoadingMore(chatId, true);
-
-    try {
-      const result = await fetchNextPage();
-
-      if (result.data) {
-        const lastPage = result.data.pages[result.data.pages.length - 1];
-        const convertedMessages = lastPage.messages.map((msg) =>
-          convertApiMessageToChatMessage(msg, chatId),
-        );
-
-        addOlderMessages(chatId, convertedMessages.reverse());
-        setNextCursor(chatId, lastPage.nextCursor);
-        setHasNextPage(chatId, !!lastPage.nextCursor);
-      }
-
-      requestAnimationFrame(() => {
-        if (container) {
-          const newScrollHeight = container.scrollHeight;
-          const addedHeight = newScrollHeight - previousScrollHeight;
-          container.scrollTop = previousScrollTop + addedHeight;
-        }
-      });
-    } catch (error) {
-      console.error("Failed to load more messages:", error);
-      showToast("메시지를 불러오는데 실패했습니다.", "error");
-    } finally {
-      setIsLoadingMore(chatId, false);
-    }
-  }, [
-    chatId,
-    hasNextPage,
-    isFetchingNextPage,
-    containerRef,
-    fetchNextPage,
-    setIsLoadingMore,
-    addOlderMessages,
-    setNextCursor,
-    setHasNextPage,
-    showToast,
-  ]);
-
   const handleScroll = useCallback(
     (e: React.UIEvent<HTMLDivElement>) => {
       const { scrollTop } = e.currentTarget;
 
       if (scrollTop === 0 && hasNextPage && !isFetchingNextPage) {
-        loadMoreMessages();
+        fetchNextPage();
       }
     },
-    [hasNextPage, isFetchingNextPage, loadMoreMessages],
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
   );
 
   useEffect(() => {
-    if (data?.pages.length) {
-      const firstPage = data.pages[0];
-      const convertedMessages = firstPage.messages.map((msg) =>
+    if (data) {
+      const lastPage = data.pages[data.pages.length - 1];
+      const convertedMessages = lastPage.messages.map((msg) =>
         convertApiMessageToChatMessage(msg, chatId),
       );
 
-      initializeWithMessages(chatId, convertedMessages.reverse(), firstPage.nextCursor);
+      addOlderMessages(chatId, convertedMessages.reverse());
+      setNextCursor(chatId, lastPage.nextCursor);
+      setHasNextPage(chatId, !!lastPage.nextCursor);
     }
-  }, [data, chatId, initializeWithMessages]);
+
+    const container = containerRef.current;
+    if (!container) return;
+    const previousScrollHeight = container.scrollHeight;
+    const previousScrollTop = container.scrollTop;
+
+    requestAnimationFrame(() => {
+      if (container) {
+        const newScrollHeight = container.scrollHeight;
+        const addedHeight = newScrollHeight - previousScrollHeight;
+        container.scrollTop = previousScrollTop + addedHeight;
+      }
+    });
+  }, [data, chatId]);
 
   return {
     currentRoom,

--- a/src/states/chatStore.ts
+++ b/src/states/chatStore.ts
@@ -12,11 +12,6 @@ interface ChatStore {
   markAsRead: () => void;
   addMessage: (chatId: string, message: ChatMessage) => void;
   addOlderMessages: (chatId: string, messages: ChatMessage[]) => void;
-  initializeWithMessages: (
-    chatId: string,
-    messages: ChatMessage[],
-    nextCursor?: string | null,
-  ) => void;
 
   initializeChatRoom: (chatId: string) => void;
   clearChatRoom: (chatId: string) => void;
@@ -24,7 +19,6 @@ interface ChatStore {
   // Pagination state
   setHasNextPage: (chatId: string, hasNext: boolean) => void;
   setNextCursor: (chatId: string, cursor: string | null) => void;
-  setIsLoadingMore: (chatId: string, isLoading: boolean) => void;
 
   // Message interactions
   updateMessageLike: (chatId: string, messageId: string, isLiked: boolean) => void;
@@ -81,20 +75,6 @@ export const useChatStore = create<ChatStore>((set) => ({
       };
     }),
 
-  initializeWithMessages: (chatId, messages, nextCursor = null) =>
-    set((state) => ({
-      chatRooms: {
-        ...state.chatRooms,
-        [chatId]: {
-          ...state.chatRooms[chatId],
-          messages,
-          nextCursor,
-          hasNextPage: !!nextCursor,
-          isLoadingMore: false,
-        },
-      },
-    })),
-
   initializeChatRoom: (chatId) =>
     set((state) => ({
       chatRooms: {
@@ -103,7 +83,6 @@ export const useChatStore = create<ChatStore>((set) => ({
           messages: [],
           hasNextPage: true,
           nextCursor: null,
-          isLoadingMore: false,
         },
       },
     })),
@@ -132,17 +111,6 @@ export const useChatStore = create<ChatStore>((set) => ({
         [chatId]: {
           ...state.chatRooms[chatId],
           nextCursor: cursor,
-        },
-      },
-    })),
-
-  setIsLoadingMore: (chatId, isLoading) =>
-    set((state) => ({
-      chatRooms: {
-        ...state.chatRooms,
-        [chatId]: {
-          ...state.chatRooms[chatId],
-          isLoadingMore: isLoading,
         },
       },
     })),

--- a/src/types/socket.types.ts
+++ b/src/types/socket.types.ts
@@ -21,5 +21,4 @@ export interface ChatRoomState {
   messages: ChatMessage[];
   hasNextPage?: boolean;
   nextCursor?: string | null;
-  isLoadingMore?: boolean;
 }


### PR DESCRIPTION
### 🔎 작업 내용
- 채팅방 내부에만 스크롤 되도록 스타일을 변경했습니다.
- 존재하지 않던 스타일들을 제거했습니다.
- 무한 스크롤에서 fetchNextPage 호출 이후 작업과 초기 데이터 세팅 로직이 충돌하여 페이지네이션이 안되던 이슈가 있었습니다. useEffect 내부에서 동일하게 작동되도록 로직을 수정했습니다.

### :loudspeaker: 전달사항
- 인풋 클릭 시 헤더가 사라지는 현상을 수정하지 못했습니다. 인스타 DM도 동일한 현상이 보여 우선 DM 기능을 올리고 추후 이슈로 등록이 될때 작업을 하는게 좋을 것 같습니다..🥲
