### PR TITLE
[Fix] 이미지 API 주소 수정

### DIFF
--- a/src/api/images/postPresigned.ts
+++ b/src/api/images/postPresigned.ts
@@ -6,15 +6,16 @@ export interface PresignedUrlRequest {
 }
 
 export interface PresignedUrlResponse {
-  url: string;
+  imageUrl: string;
   imageName: string;
+  uploadUrl: string;
 }
 
 export async function postPresignedUrl({
   type,
   ext,
 }: PresignedUrlRequest): Promise<PresignedUrlResponse> {
-  const response = await BASE_URL.post("/aws/image-upload-url", {
+  const response = await BASE_URL.post("/images/get-upload-url", {
     type,
     ext,
   });
@@ -24,6 +25,6 @@ export async function postPresignedUrl({
 export async function postPresignedUrls(
   requests: PresignedUrlRequest[],
 ): Promise<PresignedUrlResponse[]> {
-  const response = await BASE_URL.post("/aws/image-upload-urls", requests);
+  const response = await BASE_URL.post("/images/get-upload-urls", requests);
   return response.data;
 }

--- a/src/components/Modal/Background/Background.tsx
+++ b/src/components/Modal/Background/Background.tsx
@@ -5,7 +5,7 @@ import { useModalStore } from "@/states/modalStore";
 import Button from "@/components/Button/Button";
 import styles from "./Background.module.scss";
 import { useToast } from "@/hooks/useToast";
-import { postPresignedUrl } from "@/api/aws/postPresigned";
+import { postPresignedUrl } from "@/api/images/postPresigned";
 import { putBackgroundImage } from "@/api/users/putMeImage";
 import IconComponent from "@/components/Asset/Icon";
 import { useMutation } from "@tanstack/react-query";
@@ -109,7 +109,7 @@ export default function Background({ imageSrc, file, onUploadSuccess }: Backgrou
 
       updateBackgroundImage(data.imageName);
 
-      const uploadResponse = await fetch(data.url, {
+      const uploadResponse = await fetch(data.uploadUrl, {
         method: "PUT",
         body: webpFile,
         headers: {

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import router from "next/router";
 
-import { postPresignedUrls, PresignedUrlRequest } from "@/api/aws/postPresigned";
+import { postPresignedUrls, PresignedUrlRequest } from "@/api/images/postPresigned";
 
 import { DragDropContext, Droppable, DropResult } from "@hello-pangea/dnd";
 
@@ -272,7 +272,7 @@ export default function FeedForm({
       const presignedUrls = await postPresignedUrls(requests);
 
       const uploadPromises = processedFiles.map((file, index) =>
-        fetch(presignedUrls[index].url, {
+        fetch(presignedUrls[index].uploadUrl, {
           method: "PUT",
           body: file,
           headers: { "Content-Type": file.type },

--- a/src/hooks/useCoverImage.ts
+++ b/src/hooks/useCoverImage.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 import { useMutation } from "@tanstack/react-query";
 
-import { postPresignedUrl } from "@/api/aws/postPresigned";
+import { postPresignedUrl } from "@/api/images/postPresigned";
 import { putBackgroundImage } from "@/api/users/putMeImage";
 import { deleteMyBackgroundImage } from "@/api/users/deleteMeImage";
 
@@ -49,7 +49,7 @@ export const useCoverImage = (
 
       updateBackgroundImage(data.imageName);
 
-      const uploadResponse = await fetch(data.url, {
+      const uploadResponse = await fetch(data.uploadUrl, {
         method: "PUT",
         body: webpFile,
         headers: {

--- a/src/hooks/useEditorImageUploader.ts
+++ b/src/hooks/useEditorImageUploader.ts
@@ -1,4 +1,4 @@
-import { postPresignedUrl } from "@/api/aws/postPresigned";
+import { postPresignedUrl } from "@/api/images/postPresigned";
 import { imageUrl } from "@/constants/imageUrl";
 import { convertToWebP } from "@/utils/convertToWebP";
 
@@ -17,7 +17,7 @@ export const useEditorImageUploader = () => {
         ext: "webp",
       });
 
-      const uploadResponse = await fetch(data.url, {
+      const uploadResponse = await fetch(data.uploadUrl, {
         method: "PUT",
         body: webpFile,
         headers: {

--- a/src/hooks/useImageUploader.ts
+++ b/src/hooks/useImageUploader.ts
@@ -1,4 +1,4 @@
-import { postPresignedUrls, PresignedUrlRequest } from "@/api/aws/postPresigned";
+import { postPresignedUrls, PresignedUrlRequest } from "@/api/images/postPresigned";
 import { imageUrl } from "@/constants/imageUrl";
 import { convertToWebP } from "@/utils/convertToWebP";
 import { useToast } from "@/hooks/useToast";
@@ -45,7 +45,7 @@ export const useImageUploader = (options: UseImageUploaderOptions = {}) => {
 
       // 모든 파일을 병렬로 업로드
       const uploadPromises = processedFiles.map((file, index) =>
-        fetch(presignedUrls[index].url, {
+        fetch(presignedUrls[index].uploadUrl, {
           method: "PUT",
           body: file,
           headers: {

--- a/src/hooks/useProfileImage.ts
+++ b/src/hooks/useProfileImage.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-import { postPresignedUrl } from "@/api/aws/postPresigned";
+import { postPresignedUrl } from "@/api/images/postPresigned";
 import { putProfileImage } from "@/api/users/putMeImage";
 import { deleteMyProfileImage } from "@/api/users/deleteMeImage";
 
@@ -39,7 +39,7 @@ export const useProfileImage = (
 
       updateProfileImage(data.imageName);
 
-      const uploadResponse = await fetch(data.url, {
+      const uploadResponse = await fetch(data.uploadUrl, {
         method: "PUT",
         body: webpFile,
         headers: {


### PR DESCRIPTION
### 관련 이슈
- #140 

### 🔎 작업 내용
- `aws` 이미지 업로드 API 주소를 `images`로 변경했습니다.
- **Response**가 변경되어 업로드시 `uploadUrl`를 이용했습니다.

### 📸 스크린샷

### :loudspeaker: 전달사항

