### PR TITLE
[Fix] 게시글 썸네일 이미지 연결

### DIFF
--- a/src/components/Board/BoardWrite/PostForm/PostForm.module.scss
+++ b/src/components/Board/BoardWrite/PostForm/PostForm.module.scss
@@ -1,7 +1,7 @@
 @use "@/styles/globals.scss" as *;
 
 .container {
-  padding-top: 40px;
+  padding: 40px 16px;
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/components/Board/Detail/ShareBtn/ShareBtn.tsx
+++ b/src/components/Board/Detail/ShareBtn/ShareBtn.tsx
@@ -2,13 +2,13 @@ import { useModalStore } from "@/states/modalStore";
 import IconComponent from "@/components/Asset/Icon";
 import { ShareBtnProps } from "./ShareBtn.types";
 
-export default function ShareBtn({ postId, title }: ShareBtnProps) {
+export default function ShareBtn({ postId, title, thumbnail }: ShareBtnProps) {
   const openModal = useModalStore((state) => state.openModal);
 
   const handleOpenShareModal = () => {
     openModal({
       type: "SHAREPOST",
-      data: { postId, title },
+      data: { postId, title, thumbnail },
     });
   };
 

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -30,11 +30,12 @@
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%), $primary4;
     color: $gray40;
   }
-}
 
-.filled-primary.disabled {
-  background-color: $gray30;
-  color: $gray0;
+  &:disabled {
+    border-color: $gray30;
+    background-color: $gray30;
+    color: $gray0;
+  }
 }
 
 .outlined-primary {


### PR DESCRIPTION
### 🔎 작업 내용
https://github.com/Grimity/FE-Grimity/issues/168
- [x] 게시글 카카오톡 공유하기 시 썸네일 이미지 props 추가했습니다.
- [x] `filled-primary` button `disabled` 상태일 때 border가 primary로 남아있어서 수정했습니다.
- [x] 게시글 작성 페이지 양옆과 하단 padding이 누락되어 있어서 추가했습니다.

### 📸 스크린샷
<img width="313" height="362" alt="image" src="https://github.com/user-attachments/assets/ec73b7cb-2fee-4b72-b984-9c9874a3959d" />

