### PR TITLE
[Feature] 이미지 업로드 시 width, height 추가

### DIFF
--- a/src/api/images/postPresigned.ts
+++ b/src/api/images/postPresigned.ts
@@ -3,6 +3,8 @@ import BASE_URL from "@/constants/baseurl";
 export interface PresignedUrlRequest {
   type: "profile" | "feed" | "background" | "post" | "chat";
   ext: "jpg" | "jpeg" | "png" | "webp";
+  width: number;
+  height: number;
 }
 
 export interface PresignedUrlResponse {

--- a/src/components/Modal/Background/Background.tsx
+++ b/src/components/Modal/Background/Background.tsx
@@ -10,6 +10,7 @@ import { putBackgroundImage } from "@/api/users/putMeImage";
 import IconComponent from "@/components/Asset/Icon";
 import { useMutation } from "@tanstack/react-query";
 import { useMyData } from "@/api/users/getMe";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 interface BackgroundProps {
   imageSrc: string;
@@ -102,9 +103,13 @@ export default function Background({ imageSrc, file, onUploadSuccess }: Backgrou
       const croppedBlob = await getCroppedImage(imgRef.current, completedCrop);
       const webpFile = await convertToWebP(croppedBlob);
 
+      const { width, height } = await getImageDimensions(webpFile);
+
       const data = await postPresignedUrl({
         type: "background",
         ext: "webp",
+        width,
+        height,
       });
 
       updateBackgroundImage(data.imageName);

--- a/src/components/Upload/FeedForm/FeedForm.tsx
+++ b/src/components/Upload/FeedForm/FeedForm.tsx
@@ -20,6 +20,7 @@ import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
 
 import { removeUrlPrefix } from "@/utils/removeUrlPrefix";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 import styles from "@/components/Upload/FeedForm/FeedForm.module.scss";
 
@@ -262,10 +263,17 @@ export default function FeedForm({
 
       if (processedFiles.length === 0) return;
 
-      const requests: PresignedUrlRequest[] = processedFiles.map(() => ({
-        type: "feed",
-        ext: "webp",
-      }));
+      const requests: PresignedUrlRequest[] = await Promise.all(
+        processedFiles.map(async (file) => {
+          const { width, height } = await getImageDimensions(file);
+          return {
+            type: "feed",
+            ext: "webp",
+            width,
+            height,
+          };
+        }),
+      );
 
       if (requests.length === 0) return;
 

--- a/src/hooks/useCoverImage.ts
+++ b/src/hooks/useCoverImage.ts
@@ -12,6 +12,7 @@ import type { UserProfileResponse as UserData } from "@grimity/dto";
 import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
 import { convertToWebP } from "@/utils/imageConverter";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 export const useCoverImage = (
   refetchUserData: () => void,
@@ -42,9 +43,13 @@ export const useCoverImage = (
     try {
       const webpFile = await convertToWebP(file);
 
+      const { width, height } = await getImageDimensions(webpFile);
+
       const data = await postPresignedUrl({
         type: "background",
         ext: "webp",
+        width,
+        height,
       });
 
       updateBackgroundImage(data.imageName);

--- a/src/hooks/useEditorImageUploader.ts
+++ b/src/hooks/useEditorImageUploader.ts
@@ -1,6 +1,7 @@
 import { postPresignedUrl } from "@/api/images/postPresigned";
 import { imageUrl } from "@/constants/imageUrl";
 import { convertToWebP } from "@/utils/convertToWebP";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 export const useEditorImageUploader = () => {
   const uploadImage = async (blobInfo: {
@@ -12,9 +13,13 @@ export const useEditorImageUploader = () => {
 
       const webpFile = await convertToWebP(file as File);
 
+      const { width, height } = await getImageDimensions(webpFile);
+
       const data = await postPresignedUrl({
         type: "post",
         ext: "webp",
+        width,
+        height,
       });
 
       const uploadResponse = await fetch(data.uploadUrl, {

--- a/src/hooks/useImageUploader.ts
+++ b/src/hooks/useImageUploader.ts
@@ -2,6 +2,7 @@ import { postPresignedUrls, PresignedUrlRequest } from "@/api/images/postPresign
 import { imageUrl } from "@/constants/imageUrl";
 import { convertToWebP } from "@/utils/convertToWebP";
 import { useToast } from "@/hooks/useToast";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 interface UseImageUploaderOptions {
   uploadType?: PresignedUrlRequest["type"];
@@ -35,10 +36,17 @@ export const useImageUploader = (options: UseImageUploaderOptions = {}) => {
       }
 
       // Presigned URL 요청 배열 생성
-      const requests: PresignedUrlRequest[] = processedFiles.map(() => ({
-        type: uploadType,
-        ext: "webp",
-      }));
+      const requests: PresignedUrlRequest[] = await Promise.all(
+        processedFiles.map(async (file) => {
+          const { width, height } = await getImageDimensions(file);
+          return {
+            type: uploadType,
+            ext: "webp",
+            width,
+            height,
+          };
+        }),
+      );
 
       // 여러 Presigned URL 요청
       const presignedUrls = await postPresignedUrls(requests);

--- a/src/hooks/useProfileImage.ts
+++ b/src/hooks/useProfileImage.ts
@@ -7,6 +7,7 @@ import { deleteMyProfileImage } from "@/api/users/deleteMeImage";
 import { useToast } from "@/hooks/useToast";
 
 import { convertToWebP } from "@/utils/imageConverter";
+import { getImageDimensions } from "@/utils/getImageDimensions";
 
 export const useProfileImage = (
   refetchUserData: () => void,
@@ -32,9 +33,13 @@ export const useProfileImage = (
         webpFile = await convertToWebP(file);
       }
 
+      const { width, height } = await getImageDimensions(webpFile);
+
       const data = await postPresignedUrl({
         type: "profile",
         ext: "webp",
+        width,
+        height,
       });
 
       updateProfileImage(data.imageName);

--- a/src/utils/getImageDimensions.ts
+++ b/src/utils/getImageDimensions.ts
@@ -1,0 +1,21 @@
+export function getImageDimensions(file: File | Blob): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(url); // Clean up memory
+      resolve({
+        width: img.naturalWidth,
+        height: img.naturalHeight,
+      });
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Failed to load image"));
+    };
+
+    img.src = url;
+  });
+}


### PR DESCRIPTION
### 관련 이슈
- #172

### 🔎 작업 내용
- 이미지 업로드 시 `width`, `height` 파라미터를 추가했습니다.
- 이미지의 원본 크기를 가져오기 위해 `utils`폴더에 `getImageDimensions` 함수를 추가했습니다.
