### PR TITLE
[Design] 유저 프로필 링크 간격 조정

### DIFF
--- a/src/components/ProfilePage/Profile/ProfileDetails/ProfileDetails.module.scss
+++ b/src/components/ProfilePage/Profile/ProfileDetails/ProfileDetails.module.scss
@@ -83,6 +83,7 @@
 }
 
 .linkContainer {
+  margin-top: 12px;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/components/ProfilePage/Profile/ProfileDetails/ProfileDetails.tsx
+++ b/src/components/ProfilePage/Profile/ProfileDetails/ProfileDetails.tsx
@@ -71,12 +71,7 @@ export default function ProfileDetails({
         <div className={styles.followEdit}>{children}</div>
       </div>
 
-      <div
-        className={styles.descriptionContainer}
-        style={{
-          gap: userData.description && userData.links.length > 0 ? "12px" : "0",
-        }}
-      >
+      <div className={styles.descriptionContainer}>
         {userData.description && <p className={styles.description}>{userData.description}</p>}
 
         <div className={styles.linkContainer}>


### PR DESCRIPTION
### 🔎 작업 내용
- 유저 프로필에서 링크만 있을 경우 위의 간격이 없어 `gap` 대신 `margin-top`으로 간격을 수정했습니다.

### 📸 스크린샷
**AS-IS**
<img width="612" height="286" alt="image" src="https://github.com/user-attachments/assets/6a4beeec-9d0e-40ad-8ee3-b7dfff8a314b" />

**TO-BE**
<img width="612" height="286" alt="image" src="https://github.com/user-attachments/assets/71681561-1eea-46b9-b36d-994c6fafaea7" />
