### PR TITLE
[Fix] 이미지 단일 등록 시 width, height 파라미터 추가

### DIFF
--- a/src/api/images/postPresigned.ts
+++ b/src/api/images/postPresigned.ts
@@ -16,10 +16,14 @@ export interface PresignedUrlResponse {
 export async function postPresignedUrl({
   type,
   ext,
+  width,
+  height,
 }: PresignedUrlRequest): Promise<PresignedUrlResponse> {
   const response = await BASE_URL.post("/images/get-upload-url", {
     type,
     ext,
+    width,
+    height,
   });
   return response.data;
 }


### PR DESCRIPTION
### 🔎 작업 내용
- 이미지 단 건 업로드 시 width, height의 파라미터를 누락하여, width, height 값이 서버로 넘어가지 않았던 것으로 보입니다.
- 이를 수정했습니다. 