### PR TITLE
[Fix] 자유게시판 최신 글 - 이미지 파라미터 추가

### DIFF
--- a/src/components/Layout/BoardCard/BoardCard.tsx
+++ b/src/components/Layout/BoardCard/BoardCard.tsx
@@ -4,6 +4,7 @@ import { formatCurrency } from "@/utils/formatCurrency";
 import { BoardCardProps } from "./BoardCard.types";
 import Link from "next/link";
 import { timeAgo } from "@/utils/timeAgo";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function BoardCard({
   id,
@@ -17,11 +18,12 @@ export default function BoardCard({
     <div className={styles.container}>
       {thumbnail && (
         <div className={styles.thumbnailContainer}>
-          <img
+          <ResponsiveImage
             src={thumbnail}
             alt="썸네일"
             width={48}
             height={48}
+            desktopSize={600}
             className={styles.thumbnailImage}
           />
         </div>


### PR DESCRIPTION
### 🔎 작업 내용
- [x] 홈 - 자유게시판 최신 글에 이미지가 포함되어있는 경우 s 파라미터를 추가해주는 `ResponsiveImage` 컴포넌트를 추가했습니다.

### 📸 스크린샷

### :loudspeaker: 전달사항
- 이미지 자체가 48px로 작아 데스크탑과 모바일에서 `s=600`을 넘겨줬습니다.