### PR TITLE
[Fix] DM 페이지 메타데이터 추가 및 검색 엔진 차단

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,6 +6,7 @@ Disallow: /write
 Disallow: /board/write
 Disallow: /feeds/:id/edit
 Disallow: /posts/:id/edit
+Disallow: /direct
 
 Allow: /
 

--- a/src/pages/direct/[chatId].tsx
+++ b/src/pages/direct/[chatId].tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import Head from "next/head";
 
 import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
 import DirectPage from "@/components/DirectPage/DirectPage";
@@ -16,8 +17,11 @@ const DirectChatPage = () => {
   }
 
   if (isMobile || isTablet) {
-    return (
+    return (  
       <AuthLayout>
+        <Head>
+          <title>DM - 그리미티</title>
+        </Head>
         <ChatRoom chatId={chatId} />
       </AuthLayout>
     );
@@ -25,6 +29,9 @@ const DirectChatPage = () => {
 
   return (
     <AuthLayout>
+      <Head>
+        <title>DM - 그리미티</title>
+      </Head>
       <DirectPage />
       <ChatRoom chatId={chatId} />
     </AuthLayout>

--- a/src/pages/direct/index.tsx
+++ b/src/pages/direct/index.tsx
@@ -1,3 +1,5 @@
+import Head from "next/head";
+
 import DirectPage from "@/components/DirectPage/DirectPage";
 import AuthLayout from "@/components/Layout/AuthLayout/AuthLayout";
 import EmptyChatRoom from "@/components/DirectPage/EmptyChatRoom/EmptyChatRoom";
@@ -9,6 +11,9 @@ const Direct = () => {
 
   return (
     <AuthLayout>
+      <Head>
+        <title>DM - 그리미티</title>
+      </Head>
       <DirectPage />
       {!isMobile && !isTablet && <EmptyChatRoom />}
     </AuthLayout>

--- a/src/pages/following.tsx
+++ b/src/pages/following.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 
 export default function Following() {
   const router = useRouter();
-  const [OGTitle] = useState("그리미티");
+  const [OGTitle] = useState("팔로잉 - 그리미티");
   const [OGUrl, setOGUrl] = useState(serviceUrl);
   const { restoreScrollPosition } = useScrollRestoration("following-scroll");
 

--- a/src/pages/ranking.tsx
+++ b/src/pages/ranking.tsx
@@ -10,7 +10,7 @@ import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 
 function RankingPage() {
   const router = useRouter();
-  const [OGTitle] = useState("그리미티");
+  const [OGTitle] = useState("랭킹 - 그리미티");
   const [OGUrl, setOGUrl] = useState(serviceUrl);
   const { restoreScrollPosition } = useScrollRestoration("popular-scroll");
 


### PR DESCRIPTION
### 🔎 작업 내용

- [x] DM 페이지 검색 엔진 차단
- [x] DM 페이지 title 추가 및 팔로잉, 랭킹 페이지 OGTitle 수정 

### 📸 스크린샷
<img width="255" height="41" alt="image" src="https://github.com/user-attachments/assets/a1ca28aa-e47a-473e-9aad-8737006b267d" /><img width="243" height="40" alt="image" src="https://github.com/user-attachments/assets/55aeb343-3aa2-4247-864a-fa85f7f7b38c" />
