### PR TITLE
Refector: Image 컴포넌트를 ResponsiveImage로 마이그레이션

### DIFF
--- a/src/components/Detail/Author/Author.tsx
+++ b/src/components/Detail/Author/Author.tsx
@@ -1,6 +1,5 @@
 import styles from "./Author.module.scss";
 import { formatCurrency } from "@/utils/formatCurrency";
-import Image from "next/image";
 import { useState, useEffect } from "react";
 import { useAuthStore } from "@/states/authStore";
 import { usePutFollow } from "@/api/users/putIdFollow";
@@ -16,6 +15,7 @@ import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import Loader from "@/components/Layout/Loader/Loader";
 import { useDeviceStore } from "@/states/deviceStore";
 import { useRouter } from "next/router";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
   const { data: userData } = useUserData(authorId);
@@ -83,27 +83,27 @@ export default function Author({ authorId, authorUrl, feedId }: AuthorProps) {
               <Link href={`/${authorUrl}`}>
                 <div className={styles.profileLeft}>
                   {userData.image !== null ? (
-                    <Image
+                    <ResponsiveImage
                       src={userData.image}
                       alt={userData.name}
                       className={styles.authorImage}
                       width={40}
                       height={40}
-                      quality={50}
                       style={{ objectFit: "cover" }}
-                      unoptimized
+                      desktopSize={300}
+                      mobileSize={300}
                       ref={imgRef}
                     />
                   ) : (
-                    <Image
+                    <ResponsiveImage
                       src="/image/default.svg"
                       width={40}
                       height={40}
                       alt="프로필 이미지"
                       className={styles.authorImage}
-                      quality={50}
                       style={{ objectFit: "cover" }}
-                      unoptimized
+                      desktopSize={300}
+                      mobileSize={300}
                       ref={imgRef}
                     />
                   )}

--- a/src/components/Detail/Comment/Comment.tsx
+++ b/src/components/Detail/Comment/Comment.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import Image from "next/image";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -31,6 +30,7 @@ import { timeAgo } from "@/utils/timeAgo";
 import type { CommentProps, CommentWriter } from "@/components/Detail/Comment/Comment.types";
 
 import styles from "@/components/Detail/Comment/Comment.module.scss";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function Comment({ feedId, feedWriterId, isFollowingPage }: CommentProps) {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
@@ -251,24 +251,20 @@ export default function Comment({ feedId, feedWriterId, isFollowingPage }: Comme
             <div className={styles.childCommentBox}>
               <Link href={`/${reply.writer.url}`}>
                 {reply.writer.image !== null ? (
-                  <Image
+                  <ResponsiveImage
                     src={reply.writer.image}
                     width={24}
                     height={24}
                     alt="답글 프로필"
-                    quality={50}
                     className={styles.writerImage}
-                    unoptimized
                   />
                 ) : (
-                  <Image
+                  <ResponsiveImage
                     src="/image/default.svg"
                     width={24}
                     height={24}
                     alt="답글 프로필"
-                    quality={50}
                     className={styles.writerImage}
-                    unoptimized
                   />
                 )}
               </Link>
@@ -377,24 +373,20 @@ export default function Comment({ feedId, feedWriterId, isFollowingPage }: Comme
         <div className={styles.commentBox}>
           <Link href={`/${comment.writer.url}`}>
             {comment.writer.image !== null ? (
-              <Image
+              <ResponsiveImage
                 src={comment.writer.image}
                 width={isMobile ? 24 : 40}
                 height={isMobile ? 24 : 40}
                 alt="댓글 프로필"
-                quality={50}
                 className={styles.writerImage}
-                unoptimized
               />
             ) : (
-              <Image
+              <ResponsiveImage
                 src="/image/default.svg"
                 width={isMobile ? 24 : 40}
                 height={isMobile ? 24 : 40}
                 alt="댓글 프로필"
-                quality={50}
                 className={styles.writerImage}
-                unoptimized
               />
             )}
           </Link>

--- a/src/components/Detail/Comment/CommentInput/CommentInput.tsx
+++ b/src/components/Detail/Comment/CommentInput/CommentInput.tsx
@@ -1,10 +1,10 @@
-import Image from "next/image";
 import { useState } from "react";
 import styles from "./CommentInput.module.scss";
 import Button from "@/components/Button/Button";
 import { usePostFeedsComments } from "@/api/feeds-comments/postFeedComments";
 import TextArea from "@/components/TextArea/TextArea";
 import { useDeviceStore } from "@/states/deviceStore";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 interface CommentInputProps {
   feedId: string;
@@ -61,24 +61,20 @@ export default function CommentInput({
     <section className={styles.inputContainer}>
       {!isMobile &&
         (isLoggedIn && userData ? (
-          <Image
+          <ResponsiveImage
             src={userData.image !== null ? userData.image : "/image/default.svg"}
             width={40}
             height={40}
             alt="프로필 이미지"
-            quality={50}
             className={styles.writerImage}
-            unoptimized
           />
         ) : (
-          <Image
+          <ResponsiveImage
             src="/image/default.svg"
             width={40}
             height={40}
             alt="프로필 이미지"
-            quality={50}
             className={styles.writerImage}
-            unoptimized
           />
         ))}
       <TextArea

--- a/src/components/Detail/Comment/ReplyInput/ReplyInput.tsx
+++ b/src/components/Detail/Comment/ReplyInput/ReplyInput.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from "react";
-import Image from "next/image";
 
 import { useMyData } from "@/api/users/getMe";
 
@@ -7,6 +6,7 @@ import TextArea from "@/components/TextArea/TextArea";
 import Button from "@/components/Button/Button";
 
 import styles from "@/components/Detail/Comment/Comment.module.scss";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 type ToastType = "success" | "error" | "warning" | "information";
 
@@ -38,24 +38,20 @@ const ReplyInput = forwardRef<HTMLTextAreaElement, ReplyInputProps>(
     return (
       <div className={styles.input}>
         {userData && userData.image !== null ? (
-          <Image
+          <ResponsiveImage
             src={userData.image}
             width={24}
             height={24}
             alt="내 프로필"
-            quality={50}
             className={styles.writerImage}
-            unoptimized
           />
         ) : (
-          <Image
+          <ResponsiveImage
             src="/image/default.svg"
             width={24}
             height={24}
             alt="내 프로필"
-            quality={50}
             className={styles.writerImage}
-            unoptimized
           />
         )}
         <TextArea

--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -1,7 +1,6 @@
 import styles from "./Detail.module.scss";
 import { DetailProps } from "./Detail.types";
 import { useDetails } from "@/api/feeds/getFeedsId";
-import Image from "next/image";
 import { useState, useEffect, useMemo } from "react";
 import Dropdown from "../Dropdown/Dropdown";
 import { useAuthStore } from "@/states/authStore";

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
@@ -1,5 +1,4 @@
 import styles from "./FollowingFeed.module.scss";
-import Image from "next/image";
 import { useState, useEffect, useRef } from "react";
 import { useAuthStore } from "@/states/authStore";
 import { useToast } from "@/hooks/useToast";
@@ -214,31 +213,14 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
             <section className={styles.header}>
               <div className={styles.profileLeft}>
                 <Link href={`/${details.author.url}`}>
-                  {details.author.image !== null ? (
-                    <Image
-                      src={details.author.image}
-                      alt={details.author.name}
-                      className={styles.authorImage}
-                      width={40}
-                      height={40}
-                      quality={50}
-                      style={{ objectFit: "cover" }}
-                      unoptimized
-                      ref={imgRef}
-                    />
-                  ) : (
-                    <Image
-                      src="/image/default.svg"
-                      width={40}
-                      height={40}
-                      alt="프로필 이미지"
-                      className={styles.authorImage}
-                      quality={50}
-                      style={{ objectFit: "cover" }}
-                      unoptimized
-                      ref={imgRef}
-                    />
-                  )}
+                  <ResponsiveImage
+                    src={details.author.image || "/image/default.svg"}
+                    alt={details.author.name}
+                    className={styles.authorImage}
+                    width={40}
+                    height={40}
+                    ref={imgRef}
+                  />
                 </Link>
                 <div className={styles.authorInfo}>
                   <span ref={targetRef as React.RefObject<HTMLSpanElement>} {...triggerProps}>

--- a/src/components/FollowingPage/RecommendCard/RecommendCard.tsx
+++ b/src/components/FollowingPage/RecommendCard/RecommendCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { PopularUserResponse } from "@/api/users/getPopular";
 import styles from "./RecommendCard.module.scss";
-import Image from "next/image";
 import Button from "@/components/Button/Button";
 import Link from "next/link";
 import { useToast } from "@/hooks/useToast";
@@ -142,29 +141,16 @@ export default function RecommendCard({
       <div className={styles.profileWrapper}>
         <Link href={`/${url}`}>
           <div className={styles.profileLeft}>
-            {image !== null ? (
-              <Image
-                src={image}
-                width={24}
-                height={24}
-                quality={50}
-                alt="인기 유저 프로필 이미지"
-                className={styles.profileImage}
-                unoptimized
-                ref={imgRef}
-              />
-            ) : (
-              <Image
-                src="/image/default.svg"
-                width={24}
-                height={24}
-                quality={50}
-                alt="인기 유저 프로필 이미지"
-                className={styles.profileImage}
-                unoptimized
-                ref={imgRef}
-              />
-            )}
+            <ResponsiveImage
+              src={image ? image : "/image/default.svg"}
+              width={24}
+              height={24}
+              alt="인기 유저 프로필 이미지"
+              className={styles.profileImage}
+              mobileSize={300}
+              desktopSize={300}
+              ref={imgRef}
+            />
             <div className={styles.nameContainer}>
               <p className={styles.name}>{name}</p>
               <div className={styles.follower}>

--- a/src/components/Layout/Header/Default/DefaultHeader.tsx
+++ b/src/components/Layout/Header/Default/DefaultHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
-import Image from "next/image";
 import Link from "next/link";
 
 import { useMyData } from "@/api/users/getMe";
@@ -14,6 +13,7 @@ import Button from "@/components/Button/Button";
 import Notifications from "@/components/Notifications/Notifications";
 import Login from "@/components/Modal/Login/Login";
 import SideMenu from "@/components/Layout/SideMenu/SideMenu";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 import { usePreventScroll } from "@/hooks/usePreventScroll";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
@@ -209,30 +209,30 @@ export default function DefaultHeader() {
                   <div className={styles.profileContact} ref={dropdownRef}>
                     <div className={styles.profileSection}>
                       <div className={styles.profileContainer} onClick={handleToggleDropdown}>
-                        <Image
+                        <ResponsiveImage
                           src={myData.image || "/image/default.svg"}
                           width={28}
                           height={28}
                           alt="프로필 이미지"
                           className={styles.profileImage}
-                          quality={50}
                           style={{ objectFit: "cover" }}
-                          unoptimized
+                          desktopSize={300}
+                          mobileSize={300}
                         />
                       </div>
                       {isDropdownOpen && (
                         <div className={styles.dropdown}>
                           <Link href={`/${myData.url}`}>
                             <div className={styles.dropdownItem}>
-                              <Image
+                              <ResponsiveImage
                                 src={myData.image ?? "/image/default.svg"}
                                 width={32}
                                 height={32}
                                 alt="프로필 이미지"
                                 className={styles.profileImage}
-                                quality={50}
                                 style={{ objectFit: "cover" }}
-                                unoptimized
+                                desktopSize={300}
+                                mobileSize={300}
                               />
                               <span>내 프로필</span>
                             </div>

--- a/src/components/Layout/ProfileCardPopover/ProfileCardPopover.module.scss
+++ b/src/components/Layout/ProfileCardPopover/ProfileCardPopover.module.scss
@@ -26,6 +26,11 @@
     overflow: hidden;
 
     .coverImage {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 120px;
       object-fit: cover;
     }
   }

--- a/src/components/Layout/ProfileCardPopover/ProfileCardPopover.tsx
+++ b/src/components/Layout/ProfileCardPopover/ProfileCardPopover.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/router";
 
@@ -13,6 +12,7 @@ import { usePostChat } from "@/api/chats/postChat";
 
 import Button from "@/components/Button/Button";
 import ProfileCardSkeleton from "@/components/Layout/ProfileCardPopover/ProfileCardSkeleton";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 import { PATH_ROUTES } from "@/constants/routes";
 
@@ -96,25 +96,25 @@ export default function ProfileCardPopover({
       {userData && (
         <>
           <div className={styles.coverContainer}>
-            <Image
+            <ResponsiveImage
               src={userData.backgroundImage ?? "/image/default-cover.png"}
               alt={`${userData.name} 커버 이미지`}
-              fill
               className={styles.coverImage}
-              style={{ objectFit: "cover" }}
-              unoptimized
+              width={280}
+              height={120}
             />
           </div>
 
           <div className={styles.profileSection}>
             <Link href={`/${userData.url}`} className={styles.profileImageContainer}>
-              <Image
+              <ResponsiveImage
                 src={userData.image ?? "/image/default.svg"}
                 alt={userData.name}
                 className={styles.profileImage}
+                desktopSize={300}
+                mobileSize={300}
                 width={80}
                 height={80}
-                unoptimized
               />
             </Link>
           </div>

--- a/src/components/Layout/SideMenu/SideMenu.tsx
+++ b/src/components/Layout/SideMenu/SideMenu.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import Image from "next/image";
 
 import { useMyData } from "@/api/users/getMe";
 
@@ -13,6 +12,7 @@ import Button from "@/components/Button/Button";
 import FooterSection from "@/components/Layout/FooterSection/FooterSection";
 import Login from "@/components/Modal/Login/Login";
 import Icon from "@/components/Asset/IconTemp";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 import { useModal } from "@/hooks/useModal";
 
@@ -161,15 +161,14 @@ const SideMenu = ({ isOpen, onClose }: SideMenuProps) => {
                 }`}
               >
                 <Link href={`/${myData?.url}`} className={styles.mobileMyInfo} onClick={onClose}>
-                  <Image
+                  <ResponsiveImage
                     src={myData?.image || "/image/default.svg"}
                     width={32}
                     height={32}
                     alt="프로필 이미지"
                     className={styles.profileImage}
-                    quality={50}
-                    style={{ objectFit: "cover" }}
-                    unoptimized
+                    desktopSize={300}
+                    mobileSize={300}
                   />
                   <span className={styles.name}>{myData?.name}</span>
                 </Link>

--- a/src/components/Modal/Follow/Follow.tsx
+++ b/src/components/Modal/Follow/Follow.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import styles from "./Follow.module.scss";
 import { useMyFollower, useMyFollowing } from "@/api/users/getMeFollow";
-import Image from "next/image";
 import Button from "@/components/Button/Button";
 import { useRouter } from "next/router";
 import { useModalStore } from "@/states/modalStore";
@@ -10,6 +9,7 @@ import { useDeleteFollow } from "@/api/users/deleteIdFollow";
 import { useToast } from "@/hooks/useToast";
 import { FollowProps } from "./Follow.types";
 import { useDeviceStore } from "@/states/deviceStore";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function Follow({ initialTab }: FollowProps) {
   const [activeTab, setActiveTab] = useState<"follower" | "following">(initialTab);
@@ -162,29 +162,16 @@ export default function Follow({ initialTab }: FollowProps) {
           ) : (
             data.map((follow, index) => (
               <li key={index} className={styles.item}>
-                {follow.image !== null ? (
-                  <Image
-                    src={follow.image}
-                    width={isMobile ? 40 : 50}
-                    height={isMobile ? 40 : 50}
-                    quality={50}
-                    onClick={() => handleClickUser(follow.url)}
-                    className={styles.image}
-                    alt={`${activeTab === "follower" ? "팔로워" : "팔로잉"} 프로필 이미지`}
-                    unoptimized
-                  />
-                ) : (
-                  <Image
-                    src="/image/default.svg"
-                    width={isMobile ? 40 : 50}
-                    height={isMobile ? 40 : 50}
-                    quality={50}
-                    onClick={() => handleClickUser(follow.url)}
-                    className={styles.image}
-                    alt={`${activeTab === "follower" ? "팔로워" : "팔로잉"} 프로필 이미지`}
-                    unoptimized
-                  />
-                )}
+                <ResponsiveImage
+                  src={follow.image ?? "/image/default.svg"}
+                  width={isMobile ? 40 : 50}
+                  height={isMobile ? 40 : 50}
+                  onClick={() => handleClickUser(follow.url)}
+                  className={styles.image}
+                  alt={`${activeTab === "follower" ? "팔로워" : "팔로잉"} 프로필 이미지`}
+                  desktopSize={300}
+                  mobileSize={300}
+                />
                 {follow.description !== "" ? (
                   <div
                     className={styles.nameDescription}

--- a/src/components/Modal/Like/Like.tsx
+++ b/src/components/Modal/Like/Like.tsx
@@ -1,10 +1,10 @@
 import styles from "./Like.module.scss";
-import Image from "next/image";
 import { useRouter } from "next/router";
 import { useModalStore } from "@/states/modalStore";
 import { useFeedsLike } from "@/api/feeds/getFeedsIdLike";
 import Loader from "@/components/Layout/Loader/Loader";
 import { useDeviceStore } from "@/states/deviceStore";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function Like() {
   const closeModal = useModalStore((state) => state.closeModal);
@@ -31,29 +31,17 @@ export default function Like() {
           ) : (
             data.map((like, index) => (
               <li key={index} className={styles.item}>
-                {like.image !== null ? (
-                  <Image
-                    src={like.image}
-                    width={isMobile ? 40 : 50}
-                    height={isMobile ? 40 : 50}
-                    quality={50}
-                    onClick={() => handleClickUser(like.id)}
-                    className={styles.image}
-                    alt="프로필 이미지"
-                    unoptimized
-                  />
-                ) : (
-                  <Image
-                    src="/image/default.svg"
-                    width={isMobile ? 40 : 50}
-                    height={isMobile ? 40 : 50}
-                    quality={50}
-                    onClick={() => handleClickUser(like.id)}
-                    className={styles.image}
-                    alt="프로필 이미지"
-                    unoptimized
-                  />
-                )}
+                <ResponsiveImage
+                  src={like.image ?? "/image/default.svg"}
+                  width={isMobile ? 40 : 50}
+                  height={isMobile ? 40 : 50}
+                  onClick={() => handleClickUser(like.id)}
+                  className={styles.image}
+                  alt="프로필 이미지"
+                  desktopSize={300}
+                  mobileSize={300}
+                />
+
                 {like.description !== "" ? (
                   <div className={styles.nameDescription} onClick={() => handleClickUser(like.url)}>
                     <p className={styles.name}>{like.name}</p>

--- a/src/components/ProfilePage/Profile/ProfileImage/ProfileImage.tsx
+++ b/src/components/ProfilePage/Profile/ProfileImage/ProfileImage.tsx
@@ -1,11 +1,9 @@
-import Image from "next/image";
-
-import IconComponent from "@/components/Asset/Icon";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 
 import styles from "@/components/ProfilePage/Profile/ProfileImage/ProfileImage.module.scss";
 import Icon from "@/components/Asset/IconTemp";
 import { useRef } from "react";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 interface ProfileImageProps {
   profileImage: string;
@@ -33,14 +31,12 @@ export default function ProfileImage({
 
   return (
     <div className={styles.profileImageContainer}>
-      <Image
+      <ResponsiveImage
         src={profileImage}
         width={isMobile ? 80 : 140}
         height={isMobile ? 80 : 140}
-        quality={75}
         alt="프로필 이미지"
         className={styles.profileImage}
-        unoptimized
         ref={imgRef}
       />
       {isMyProfile && (

--- a/src/components/RankingPage/PopularUser/User/User.tsx
+++ b/src/components/RankingPage/PopularUser/User/User.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { PopularUserResponse } from "@/api/users/getPopular";
 import styles from "./User.module.scss";
-import Image from "next/image";
 import Button from "@/components/Button/Button";
 import Link from "next/link";
 import { useToast } from "@/hooks/useToast";
 import { usePutFollow } from "@/api/users/putIdFollow";
 import { useDeleteFollow } from "@/api/users/deleteIdFollow";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function User({
   id,
@@ -100,29 +100,14 @@ export default function User({
       <div className={styles.profileWrapper}>
         <Link href={`/${url}`}>
           <div className={styles.profileLeft}>
-            {image !== null ? (
-              <Image
-                src={image}
-                width={24}
-                height={24}
-                quality={50}
-                alt="인기 유저 프로필 이미지"
-                className={styles.profileImage}
-                unoptimized
-                ref={imgRef}
-              />
-            ) : (
-              <Image
-                src="/image/default.svg"
-                width={24}
-                height={24}
-                quality={50}
-                alt="인기 유저 프로필 이미지"
-                className={styles.profileImage}
-                unoptimized
-                ref={imgRef}
-              />
-            )}
+            <ResponsiveImage
+              src={image || "/image/default.svg"}
+              width={24}
+              height={24}
+              alt="인기 유저 프로필 이미지"
+              className={styles.profileImage}
+              ref={imgRef}
+            />
             <div className={styles.nameContainer}>
               <p className={styles.name}>{name}</p>
               <div className={styles.follower}>

--- a/src/components/SearchPage/User/SearchProfile/SearchProfile.tsx
+++ b/src/components/SearchPage/User/SearchProfile/SearchProfile.tsx
@@ -1,7 +1,6 @@
 import { useState, useContext } from "react";
 import styles from "./SearchProfile.module.scss";
 import { formatCurrency } from "@/utils/formatCurrency";
-import Image from "next/image";
 import Link from "next/link";
 import { useAuthStore } from "@/states/authStore";
 import { SearchedUserResponse } from "@grimity/dto";
@@ -11,6 +10,7 @@ import { useToast } from "@/hooks/useToast";
 import Button from "@/components/Button/Button";
 import { useDeviceStore } from "@/states/deviceStore";
 import { SearchHighlightContext } from "@/pages/search";
+import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
 
 export default function SearchProfile({
   id,
@@ -77,14 +77,12 @@ export default function SearchProfile({
       <div className={styles.profile}>
         <div className={styles.topRow}>
           <Link href={`/${url}`}>
-            <Image
+            <ResponsiveImage
               src={image !== null ? image : "/image/default.svg"}
               alt="프로필"
               width={64}
               height={64}
-              quality={75}
               className={styles.image}
-              unoptimized
             />
           </Link>
           {isShowFollowButton && (


### PR DESCRIPTION
### 관련 이슈
- #186 

### 🔎 작업 내용
- [x] 프로필 이미지 resize 수정
- [x] `Image` 컴포넌트를 `ResponsiveImage`로 마이그레이션 (16개 파일)
  - Detail (Author, Comment, CommentInput, ReplyInput)
  - FollowingPage (FollowingFeed, RecommendCard)
  - Layout (DefaultHeader, ProfileCardPopover, SideMenu)
  - Modal (Follow, Like)
  - Profile (ProfileImage)
  - RankingPage (PopularUser/User)
  - Search (SearchProfile)

### 📸 스크린샷

### :loudspeaker: 전달사항
- 기존 `next/image`의 `Image` 컴포넌트를 `ResponsiveImage` 컴포넌트로 통일
