### PR TITLE
[Design] 메인 - 배너 외곽선 추가

### DIFF
--- a/src/components/Layout/Banner/Banner.module.scss
+++ b/src/components/Layout/Banner/Banner.module.scss
@@ -2,4 +2,6 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  box-shadow: 0 0 0 1px #edeef0;
+  border-radius: 12px;
 }


### PR DESCRIPTION
### 관련이슈
- #212 

### 🔎 작업 내용
- `border`를 이용하면 이미지가 작아지기에 `shadow`를 사용하여 외곽선을 줬습니다. 

### 📸 스크린샷
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/f344af57-49c7-47c9-872c-0a56f231aaaf" />
