### PR TITLE
[Feature] 디자인 시스템 - BottomSheet

### DIFF
--- a/src/components/common/PopUp/BottomSheet/BottomSheet.module.scss
+++ b/src/components/common/PopUp/BottomSheet/BottomSheet.module.scss
@@ -1,0 +1,128 @@
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/radius" as radius;
+@use "@/styles/tokens/spacing" as spacing;
+@use "@/styles/tokens/typography/semantic" as typo;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1501;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  background-color: colors.$bg-overlay-black;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.sheet {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: min(460px, 90vh);
+  border-radius: radius.$radius-xl radius.$radius-xl 0 0;
+  background-color: colors.$surface-base;
+  overflow: hidden;
+  animation: slideUp 0.3s ease-out;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.header {
+  height: 56px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: spacing.$spacing-12;
+  padding: 0 spacing.$spacing-20;
+  background-color: colors.$surface-base;
+
+  .headerLeft {
+    display: flex;
+    align-items: center;
+    gap: spacing.$spacing-12;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .headerRight {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .iconButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: none;
+    border: none;
+    color: colors.$icon-gray-bold;
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .closeButton {
+    width: 32px;
+    height: 32px;
+    border-radius: radius.$radius-full;
+  }
+
+  .title {
+    margin: 0;
+    min-width: 0;
+    @include typo.title-3;
+    color: colors.$text-gray-bold;
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: spacing.$spacing-8 spacing.$spacing-20 spacing.$spacing-20;
+}
+
+.footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: spacing.$spacing-8;
+  padding: 0 spacing.$spacing-20 spacing.$spacing-20;
+
+  .buttonWrap {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+
+    button {
+      width: 100%;
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/src/components/common/PopUp/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/common/PopUp/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,118 @@
+import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from "@storybook/react";
+import BottomSheet from "./BottomSheet";
+
+const meta = {
+  title: "Common/PopUp/BottomSheet",
+  component: BottomSheet,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    buttonType: {
+      options: ["primary", "secondary", "tertiary", "double", undefined],
+      control: { type: "radio" },
+    },
+  },
+} satisfies Meta<typeof BottomSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultChildren = (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flex: 1,
+      minHeight: 200,
+      backgroundColor: "var(--surface-gray-subtler, #edeef0)",
+    }}
+  >
+    <p style={{ margin: 0, fontSize: 28, fontWeight: 700 }}>Hug로 내용물 감싸기</p>
+  </div>
+);
+
+export const Primary: Story = {
+  args: {
+    isOpen: true,
+    title: "제목",
+    showArrow: true,
+    showCloseIcon: true,
+    onBack: action("back"),
+    onClose: action("close"),
+    children: defaultChildren,
+    buttonType: "primary",
+    primaryLabel: "label",
+    onPrimary: action("primary"),
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    isOpen: true,
+    title: "제목",
+    showArrow: true,
+    showCloseIcon: true,
+    onBack: action("back"),
+    onClose: action("close"),
+    children: defaultChildren,
+    buttonType: "secondary",
+    secondaryLabel: "Label",
+    onSecondary: action("secondary"),
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    isOpen: true,
+    title: "제목",
+    showArrow: true,
+    showCloseIcon: true,
+    onBack: action("back"),
+    onClose: action("close"),
+    children: defaultChildren,
+    buttonType: "tertiary",
+  },
+};
+
+export const TwoButtons: Story = {
+  args: {
+    isOpen: true,
+    title: "제목",
+    showArrow: true,
+    showCloseIcon: true,
+    onBack: action("back"),
+    onClose: action("close"),
+    children: defaultChildren,
+    buttonType: "double",
+    primaryLabel: "label",
+    onPrimary: action("primary"),
+    secondaryLabel: "Label",
+    onSecondary: action("secondary"),
+  },
+};
+
+export const MinimalChildren: Story = {
+  args: {
+    isOpen: true,
+    onClose: action("close"),
+    children: <p style={{ margin: 0 }}>기존 children-only 패턴 호환</p>,
+  },
+};
+
+export const Exceed: Story = {
+  args: {
+    isOpen: true,
+    title: "제목",
+    showArrow: true,
+    showCloseIcon: true,
+    onBack: action("back"),
+    onClose: action("close"),
+    exceed: true,
+    children: defaultChildren,
+    buttonType: "primary",
+    primaryLabel: "label",
+    onPrimary: action("primary"),
+  },
+};

--- a/src/components/common/PopUp/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/PopUp/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect } from "react";
+import clsx from "clsx";
+import { usePreventScroll } from "@/hooks/usePreventScroll";
+import SolidButton from "@/components/common/Button/SolidButton/SolidButton";
+import OutlinedButton from "@/components/common/Button/OutlinedButton/OutlinedButton";
+import Icon from "@/components/common/Icon/Icon";
+import styles from "./BottomSheet.module.scss";
+import type { BottomSheetProps } from "./BottomSheet.types";
+
+export default function BottomSheet(props: BottomSheetProps) {
+  const {
+    isOpen,
+    onClose,
+    children,
+    title,
+    showArrow = false,
+    showCloseIcon = false,
+    onBack,
+    exceed = false,
+    className,
+  } = props;
+
+  usePreventScroll(isOpen);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const hasHeader = showArrow || !!title || showCloseIcon;
+  const hasFooter =
+    !exceed &&
+    (props.buttonType === "primary" ||
+      props.buttonType === "secondary" ||
+      props.buttonType === "double");
+
+  return (
+    <div
+      className={clsx(styles.overlay, className)}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "bottomsheet-title" : undefined}
+    >
+      <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
+        {hasHeader && (
+          <header className={styles.header}>
+            <div className={styles.headerLeft}>
+              {showArrow && onBack != null && (
+                <button
+                  type="button"
+                  className={styles.iconButton}
+                  onClick={onBack}
+                  aria-label="뒤로가기"
+                >
+                  <Icon name="chevron-left-tight-thick" size={24} />
+                </button>
+              )}
+              {title && (
+                <h2 id="bottomsheet-title" className={styles.title}>
+                  {title}
+                </h2>
+              )}
+            </div>
+            {showCloseIcon && (
+              <div className={styles.headerRight}>
+                <button
+                  type="button"
+                  className={clsx(styles.iconButton, styles.closeButton)}
+                  onClick={onClose}
+                  aria-label="닫기"
+                >
+                  <Icon name="x-thick" size={24} />
+                </button>
+              </div>
+            )}
+          </header>
+        )}
+
+        <div className={styles.content}>{children}</div>
+
+        {hasFooter && (
+          <footer className={styles.footer}>
+            {props.buttonType === "double" && (
+              <>
+                <div className={styles.buttonWrap}>
+                  <OutlinedButton size="large" onClick={props.onSecondary}>
+                    {props.secondaryLabel}
+                  </OutlinedButton>
+                </div>
+                <div className={styles.buttonWrap}>
+                  <SolidButton size="large" onClick={props.onPrimary}>
+                    {props.primaryLabel}
+                  </SolidButton>
+                </div>
+              </>
+            )}
+            {props.buttonType === "primary" && (
+              <div className={styles.buttonWrap}>
+                <SolidButton size="large" onClick={props.onPrimary}>
+                  {props.primaryLabel}
+                </SolidButton>
+              </div>
+            )}
+            {props.buttonType === "secondary" && (
+              <div className={styles.buttonWrap}>
+                <OutlinedButton size="large" onClick={props.onSecondary}>
+                  {props.secondaryLabel}
+                </OutlinedButton>
+              </div>
+            )}
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/PopUp/BottomSheet/BottomSheet.types.ts
+++ b/src/components/common/PopUp/BottomSheet/BottomSheet.types.ts
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+type ButtonConfig =
+  | {
+      buttonType: "primary";
+      primaryLabel: string;
+      onPrimary: () => void;
+    }
+  | {
+      buttonType: "secondary";
+      secondaryLabel: string;
+      onSecondary: () => void;
+    }
+  | { buttonType: "tertiary" }
+  | {
+      buttonType: "double";
+      primaryLabel: string;
+      onPrimary: () => void;
+      secondaryLabel: string;
+      onSecondary: () => void;
+    }
+  | { buttonType?: never };
+
+export type BottomSheetProps = ButtonConfig & {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  showArrow?: boolean;
+  showCloseIcon?: boolean;
+  onBack?: () => void;
+  exceed?: boolean;
+  className?: string;
+};


### PR DESCRIPTION
### 🔎 작업 내용

  - [x] BottomSheet 컴포넌트 구현 (`src/components/common/PopUp/BottomSheet/`)
  - [x] 헤더 영역: 뒤로가기 화살표(`showArrow`), 타이틀(`title`), 닫기 아이콘(`showCloseIcon`)
   선택적 노출
  - [x] 푸터 버튼 타입 discriminated union 적용 — `primary` / `secondary` / `double` /
  `tertiary` / 없음
  - [x] 오버레이 클릭 및 Escape 키로 닫기 지원
  - [x] `usePreventScroll` 훅으로 시트 열림 시 스크롤 잠금
  - [x] WAI-ARIA 접근성 속성 적용 (`role="dialog"`, `aria-modal`, `aria-labelledby`)
  - [x] Storybook 스토리 작성 (헤더/버튼 조합별 시나리오 포함)

  ### 📸 스크린샷
<img width="1840" height="1113" alt="image" src="https://github.com/user-attachments/assets/c27fe776-b0f4-4bf3-9506-a9fafb4a738c" />


  ### :loudspeaker: 전달사항

  - `exceed` prop을 `true`로 설정하면 푸터 버튼 영역 없이 콘텐츠가 시트 전체를 차지합니다.
  - 버튼 타입은 discriminated union으로 타입 안전하게 구성되어 있어, 각 타입에 필요한 `label` / `handler`가 누락되면 컴파일 에러가 발생합니다.