### PR TITLE
[Feature] 디자인 시스템 반영(보관함)

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -14,7 +14,6 @@ import { useOnClickOutside } from "@/hooks/useOnClickOutside";
 import { usePreventScroll } from "@/hooks/usePreventScroll";
 import useGoBack from "@/hooks/useGoBack";
 
-import IconComponent from "@/components/Asset/Icon";
 import IconButton from "@/components/common/Button/IconButton/IconButton";
 import Icon from "@/components/common/Icon/Icon";
 import Menu from "@/components/common/Navigation/Menu/Menu";
@@ -56,8 +55,6 @@ const SUB_SEARCH_HIDDEN_ROUTES = [
   "/posts/[id]",
   "/direct",
 ];
-const SCROLL_TOP_THRESHOLD = 300;
-
 export default function Layout({ children }: LayoutProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -65,7 +62,7 @@ export default function Layout({ children }: LayoutProps) {
   const { goBack } = useGoBack();
 
   // ─── 전역 상태 ─────────────────────────────────────────────────────────
-  const { isMobile, isTablet } = useDeviceStore();
+  const { isMobile } = useDeviceStore();
   const {
     isLoggedIn,
     isAuthReady,
@@ -80,7 +77,6 @@ export default function Layout({ children }: LayoutProps) {
   const { socket, isConnected } = useSocket();
 
   // ─── 로컬 상태 ─────────────────────────────────────────────────────────
-  const [isScrollAbove, setIsScrollAbove] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
   const [isProfileDropdownOpen, setIsProfileDropdownOpen] = useState(false);
@@ -163,7 +159,14 @@ export default function Layout({ children }: LayoutProps) {
   );
 
   const gnbVariant: GNBVariant = useMemo(() => {
-    if (isSubRoute) return "three-button";
+    if (isSubRoute) {
+      switch (router.pathname) {
+        case "/mypage":
+          return "depth-2";
+        default:
+          return "three-button";
+      }
+    }
     if (isMobile) {
       if (!isAuthReady || !isLoggedIn) {
         return isMobileSidebarOpen ? "guest-menu" : "guest";
@@ -171,7 +174,7 @@ export default function Layout({ children }: LayoutProps) {
       return "main";
     }
     return isLoggedIn ? "pc-main" : "pc-guest";
-  }, [isSubRoute, isMobile, isAuthReady, isLoggedIn, isMobileSidebarOpen]);
+  }, [isSubRoute, isMobile, isAuthReady, isLoggedIn, isMobileSidebarOpen, router.pathname]);
 
   const subRightActions = useMemo<GNBProps["rightActions"]>(() => {
     if (!isSubRoute) return undefined;
@@ -215,11 +218,6 @@ export default function Layout({ children }: LayoutProps) {
         borderBottom: true,
       },
       { label: "좋아요한 그림", onClick: () => navigate("/mypage?tab=liked-feeds") },
-      {
-        label: "저장한 그림",
-        onClick: () => navigate("/mypage?tab=saved-feeds"),
-        borderBottom: true,
-      },
       {
         label: "저장한 글",
         onClick: () => navigate("/mypage?tab=saved-posts"),
@@ -300,13 +298,6 @@ export default function Layout({ children }: LayoutProps) {
     };
   }, [isConnected, currentChatId, setHasUnreadMessages, queryClient, user_id]);
 
-  // 스크롤 위치 감지
-  useEffect(() => {
-    const handler = () => setIsScrollAbove(window.scrollY > SCROLL_TOP_THRESHOLD);
-    window.addEventListener("scroll", handler);
-    return () => window.removeEventListener("scroll", handler);
-  }, []);
-
   // 로그인 상태 변경 시 프로필 드롭다운·모바일 사이드바 닫기
   useEffect(() => {
     setIsProfileDropdownOpen(false);
@@ -383,17 +374,6 @@ export default function Layout({ children }: LayoutProps) {
           {children}
         </div>
       </div>
-
-      {!isMobile && !isTablet && (
-        <div
-          className={`${styles.topButton} ${isScrollAbove && styles.show}`}
-          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          role="button"
-          tabIndex={0}
-        >
-          <IconComponent name="up" size={28} isBtn />
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/MyPage/LikedFeeds/LikedFeeds.module.scss
+++ b/src/components/MyPage/LikedFeeds/LikedFeeds.module.scss
@@ -1,34 +1,25 @@
-@use "@/styles/globals.scss" as *;
+@use "@/styles/tokens/spacing" as spacing;
+@use "@/styles/breakpoint" as bp;
 
-.cardContainer {
-  margin-top: 20px;
+.grid {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  row-gap: 40px;
-  column-gap: 16px;
+  grid-template-columns: repeat(5, 1fr);
+  gap: spacing.$spacing-16;
+  margin-top: spacing.$spacing-20;
 
-  @include Size("mobile") {
-    grid-template-columns: repeat(2, 1fr);
-    row-gap: 20px;
-    column-gap: 12px;
-    margin-top: 68px;
+  @include bp.breakpoint-down("sm") {
+    grid-template-columns: repeat(4, 1fr);
   }
 
-  @include Size("tablet") {
-    grid-template-columns: repeat(3, 1fr);
-    row-gap: 20px;
-    column-gap: 16px;
+  @include bp.breakpoint-down("xs") {
+    grid-template-columns: repeat(2, 1fr);
+    margin-top: spacing.$spacing-16;
   }
 }
 
-.noResult {
-  @include Sub2;
-  color: $gray50;
+.emptyWrap {
   width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 100px 0;
-  gap: 24px;
+  justify-content: center;
 }

--- a/src/components/MyPage/LikedFeeds/LikedFeeds.tsx
+++ b/src/components/MyPage/LikedFeeds/LikedFeeds.tsx
@@ -1,77 +1,73 @@
-import Button from "@/components/Button/Button";
-import styles from "./LikedFeeds.module.scss";
-import { useMyLikeList } from "@/api/users/getMeLikeFeeds";
-import ProfileCard from "@/components/Layout/ProfileCard/ProfileCard";
-import Link from "next/link";
-import { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
+
+import { useMyLikeList } from "@/api/users/getMeLikeFeeds";
+import { useAuthStore } from "@/states/authStore";
+import { useFeedsLikeMutation } from "@/queries/feeds/useFeedsLikeMutation";
+import { useGlobalLoading } from "@/hooks/useGlobalLoading";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+
+import Album from "@/components/common/Card/Album/Album";
+import Empty from "@/components/common/Empty/Empty";
+
 import { PATH_ROUTES } from "@/constants/routes";
 
+import styles from "./LikedFeeds.module.scss";
+
 export default function LikedFeeds() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } = useMyLikeList({
+  const router = useRouter();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const { mutate: toggleLike } = useFeedsLikeMutation();
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useMyLikeList({
     size: 20,
   });
-  const observerRef = useRef<HTMLDivElement | null>(null);
-  const { pathname } = useRouter();
-  useEffect(() => {
-    refetch();
-  }, [pathname]);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 1.0 },
+  useGlobalLoading(isLoading);
+
+  const { loadMoreRef } = useInfiniteScroll({
+    hasNextPage: Boolean(hasNextPage),
+    isFetching: isFetchingNextPage,
+    onLoadMore: fetchNextPage,
+  });
+
+  if (isLoading) return null;
+
+  const feeds = data?.pages.flatMap((page) => page.feeds) ?? [];
+
+  if (feeds.length === 0) {
+    return (
+      <div className={styles.emptyWrap}>
+        <Empty
+          iconName="illust-result-null"
+          title="좋아요한 그림이 없어요"
+          buttonLabel="인기 그림 둘러보기"
+          onButtonClick={() => router.push(PATH_ROUTES.RANKING)}
+        />
+      </div>
     );
-
-    if (observerRef.current) {
-      observer.observe(observerRef.current);
-    }
-
-    return () => {
-      if (observerRef.current) {
-        observer.unobserve(observerRef.current);
-      }
-    };
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const isEmpty = !data || !data.pages || data.pages.every((page) => page.feeds.length === 0);
+  }
 
   return (
     <>
-      {isEmpty ? (
-        <div className={styles.noResult}>
-          아직 좋아요한 그림이 없어요
-          <Link href={PATH_ROUTES.RANKING}>
-            <Button size="m" type="filled-primary">
-              인기그림 둘러보기
-            </Button>
-          </Link>
-        </div>
-      ) : (
-        <section className={styles.cardContainer}>
-          {data &&
-            data.pages.flat().map((page) =>
-              page.feeds.map((feed, index) => (
-                <div key={`${feed.id}-${index}`}>
-                  <ProfileCard
-                    title={feed.title}
-                    cards={feed.cards}
-                    thumbnail={feed.thumbnail}
-                    likeCount={feed.likeCount}
-                    commentCount={feed.commentCount}
-                    createdAt={feed.createdAt}
-                    id={feed.id}
-                  />
-                </div>
-              )),
-            )}
-        </section>
-      )}
-      <div ref={observerRef} />
+      <section className={styles.grid}>
+        {feeds.map((feed) => (
+          <Album
+            key={feed.id}
+            variant="mainTitle"
+            linkHref={`${PATH_ROUTES.FEEDS}/${feed.id}`}
+            imageUrl={feed.thumbnail}
+            title={feed.title}
+            nickname={feed.author?.name ?? ""}
+            likeCount={feed.likeCount}
+            viewCount={feed.viewCount}
+            isLiked
+            onLikeClick={
+              isLoggedIn ? () => toggleLike({ id: feed.id, isLiked: true }) : undefined
+            }
+          />
+        ))}
+      </section>
+      <div ref={loadMoreRef} />
     </>
   );
 }

--- a/src/components/MyPage/MyPage.module.scss
+++ b/src/components/MyPage/MyPage.module.scss
@@ -1,96 +1,37 @@
 @use "@/styles/globals.scss" as *;
+@use "@/styles/breakpoint" as *;
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/typography/semantic" as typo;
+@use "@/styles/tokens/spacing" as spacing;
 
 .container {
   width: 100%;
-  height: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-top: 60px;
+  justify-content: center;
+  padding: spacing.$spacing-48 spacing.$spacing-20 spacing.$spacing-20;
 
-  @include Size("mobile") {
-    padding-top: 0px;
-  }
-
-  @include Size("tablet") {
-    padding-top: 32px;
-  }
-
-  .wrapper {
-    padding-left: 32px;
-    padding-right: 32px;
-    padding-bottom: 80px;
-
-    @include Size("mobile") {
-      padding-left: 16px;
-      padding-right: 16px;
-      padding-top: 90px;
-    }
-
-    @include Size("tablet") {
-      padding-left: 16px;
-      padding-right: 16px;
-    }
-  }
-
-  .center {
-    max-width: $max-width-container;
-    margin: 0 auto;
+  @include breakpoint-down("xs") {
+    padding: spacing.$spacing-16 spacing.$spacing-16 spacing.$spacing-20;
   }
 }
 
-.navContainer {
-  max-width: $max-width-container;
-  margin: 0 auto;
+.center {
   width: 100%;
-  margin-bottom: 12px;
+  max-width: $max-width-container;
+}
 
-  @include Size("mobile") {
-    padding: 16px 0 0;
-    position: fixed;
-    top: 64px;
-    left: 0;
-    z-index: 2;
-    background-color: $gray0;
+.title {
+  margin: 0 0 spacing.$spacing-24;
+  color: colors.$text-gray-bold;
+  @include typo.title-1;
+
+  @include breakpoint-down("xs") {
+    margin-bottom: spacing.$spacing-12;
+    @include typo.title-2;
   }
+}
 
-  .underline {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 2px;
-    background-color: $gray70;
-    transition: all 0.3s ease;
-  }
 
-  .button {
-    padding: 0 12px 8px;
-    background: none;
-    border: none;
-    color: $gray60;
-    @include Sub2;
-    transition: all 0.3s;
-    cursor: pointer;
-
-    @include Size("mobile") {
-      @include Sub4;
-      padding: 0 0 8px;
-    }
-
-    &:hover {
-      color: $gray70;
-    }
-
-    &.selected {
-      color: $gray70;
-    }
-  }
-
-  .bar {
-    width: 1px;
-    height: 20px;
-    background-color: $gray30;
-    padding: 0;
-    margin-bottom: 8px;
-  }
+.content {
+  width: 100%;
 }

--- a/src/components/MyPage/MyPage.tsx
+++ b/src/components/MyPage/MyPage.tsx
@@ -1,34 +1,31 @@
 import { useRouter } from "next/router";
 import LikedFeeds from "./LikedFeeds/LikedFeeds";
-import SavedFeeds from "./SavedFeeds/SavedFeeds";
 import SavedPosts from "./SavedPosts/SavedPosts";
 
 import UnderlineTabs from "@/components/UnderlineTabs/UnderlineTabs";
 
 import styles from "./MyPage.module.scss";
 
-type TabKey = "liked-feeds" | "saved-feeds" | "saved-posts";
+type TabKey = "liked-feeds" | "saved-posts";
 
 const TABS: { key: TabKey; label: string; hasSeparatorAfter?: boolean }[] = [
   { key: "liked-feeds", label: "좋아요한 그림" },
-  { key: "saved-feeds", label: "저장한 그림", hasSeparatorAfter: true },
   { key: "saved-posts", label: "저장한 글" },
 ];
 
 export default function MyPage() {
   const router = useRouter();
   const { tab } = router.query;
+  const activeTab = (tab as TabKey) ?? "liked-feeds";
 
   const handleTabChange = (tabKey: TabKey) => {
     router.push(`?tab=${tabKey}`);
   };
 
   const getTabComponent = () => {
-    switch (tab) {
+    switch (activeTab) {
       case "liked-feeds":
         return <LikedFeeds />;
-      case "saved-feeds":
-        return <SavedFeeds />;
       case "saved-posts":
         return <SavedPosts />;
       default:
@@ -38,12 +35,10 @@ export default function MyPage() {
 
   return (
     <div className={styles.container}>
-      <section className={styles.navContainer}>
-        <UnderlineTabs tabs={TABS} activeTab={tab as TabKey} onTabChange={handleTabChange} />
-      </section>
-
-      <div className={styles.wrapper}>
-        <div className={styles.center}>{getTabComponent()}</div>
+      <div className={styles.center}>
+        <h1 className={styles.title}>내 보관함</h1>
+        <UnderlineTabs tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
+        <div className={styles.content}>{getTabComponent()}</div>
       </div>
     </div>
   );

--- a/src/components/MyPage/SavedPosts/SavedPosts.module.scss
+++ b/src/components/MyPage/SavedPosts/SavedPosts.module.scss
@@ -1,78 +1,38 @@
-@use "@/styles/globals.scss" as *;
+@use "@/styles/tokens/spacing" as spacing;
+@use "@/styles/breakpoint" as bp;
 
-.cardContainer {
+.list {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-top: 32px;
-  margin-bottom: 40px;
+  margin-top: spacing.$spacing-20;
+  margin-bottom: spacing.$spacing-40;
 
-  @include Size("mobile") {
-    margin-top: 68px;
-    margin-bottom: 70px;
+  @include bp.breakpoint-down("xs") {
+    margin-bottom: spacing.$spacing-28;
   }
+}
 
-  @include Size("tablet") {
-    margin-top: 20px;
-  }
+.itemLink {
+  display: block;
+  width: 100%;
+}
+
+.emptyWrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .pagination {
-  margin-top: 8px;
+  margin-top: spacing.$spacing-8;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: spacing.$spacing-8;
 
-  @include Size("mobile") {
-    margin-top: 28px;
-    gap: 4px;
+  @include bp.breakpoint-down("xs") {
+    margin-top: spacing.$spacing-28;
+    gap: spacing.$spacing-4;
   }
-
-  button {
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: $gray0;
-    border: none;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    @include Label2;
-    color: $gray70;
-
-    &:hover {
-      background-color: $gray10;
-    }
-  }
-
-  .paginationArrow {
-    background-color: transparent;
-    border: none;
-
-    &:hover {
-      background-color: $gray10;
-    }
-
-    &:disabled {
-      display: none;
-    }
-  }
-
-  .active {
-    background-color: $gray20;
-  }
-}
-
-.noResult {
-  @include Sub2;
-  color: $gray50;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 100px 0;
-  gap: 24px;
 }

--- a/src/components/MyPage/SavedPosts/SavedPosts.tsx
+++ b/src/components/MyPage/SavedPosts/SavedPosts.tsx
@@ -38,13 +38,14 @@ export default function SavedPosts() {
 
   // page 쿼리 없으면 page=1로 보정
   useEffect(() => {
+    if (!router.isReady) return;
     if (router.query.page) return;
     router.replace(
       { pathname: router.pathname, query: { ...router.query, page: 1 } },
       undefined,
       { shallow: true },
     );
-  }, [router]);
+  }, [router.isReady, router.pathname, router.query.page]);
 
   const posts = data?.posts ?? [];
   const totalPages = Math.ceil((data?.totalCount ?? 0) / PAGE_SIZE);

--- a/src/components/MyPage/SavedPosts/SavedPosts.tsx
+++ b/src/components/MyPage/SavedPosts/SavedPosts.tsx
@@ -1,65 +1,105 @@
 import { useEffect } from "react";
-import { useRouter } from "next/router";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useMySavePost } from "@/api/users/getMeSavePosts";
+import { deletePostsSave } from "@/api/posts/putDeletePostsIdSave";
+import { useGlobalLoading } from "@/hooks/useGlobalLoading";
+import { useToast } from "@/hooks/useToast";
 
-import AllCard from "@/components/Board/BoardAll/AllCard/AllCard";
-import Loader from "@/components/Layout/Loader/Loader";
-import Button from "@/components/Button/Button";
+import Empty from "@/components/common/Empty/Empty";
+import UserItem from "@/components/common/Cell/UserItem/UserItem";
 import Pagination from "@/components/Pagination";
+
+import { PATH_ROUTES } from "@/constants/routes";
+import { timeAgo } from "@/utils/timeAgo";
 
 import styles from "./SavedPosts.module.scss";
 
+const PAGE_SIZE = 10;
+
+const POST_TYPE_LABEL: Record<string, string> = {
+  QUESTION: "질문",
+  FEEDBACK: "피드백",
+  NOTICE: "공지",
+  NORMAL: "일반",
+};
+
 export default function SavedPosts() {
   const router = useRouter();
-  const currentPage = parseInt(router.query.page as string) || 1;
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
-  const { data, isLoading, refetch } = useMySavePost({
-    size: 10,
-    page: currentPage,
-  });
-  const { pathname } = useRouter();
+  const currentPage = Number(router.query.page) || 1;
+  const { data, isLoading } = useMySavePost({ size: PAGE_SIZE, page: currentPage });
+
+  useGlobalLoading(isLoading);
+
+  // page 쿼리 없으면 page=1로 보정
   useEffect(() => {
-    refetch();
-  }, [pathname]);
-  const posts = data?.posts || [];
-  const totalPages = Math.ceil((data?.totalCount || 0) / 10);
+    if (router.query.page) return;
+    router.replace(
+      { pathname: router.pathname, query: { ...router.query, page: 1 } },
+      undefined,
+      { shallow: true },
+    );
+  }, [router]);
+
+  const posts = data?.posts ?? [];
+  const totalPages = Math.ceil((data?.totalCount ?? 0) / PAGE_SIZE);
 
   const handlePageChange = (page: number) => {
     if (page < 1 || page > totalPages) return;
-    router.push({
-      pathname: router.pathname,
-      query: { ...router.query, page },
-    });
+    router.push({ pathname: router.pathname, query: { ...router.query, page } });
   };
 
-  useEffect(() => {
-    if (!router.query.page) {
-      router.replace({
-        pathname: router.pathname,
-        query: { ...router.query, page: 1 },
-      });
+  const handleUnsave = async (e: React.MouseEvent | undefined, id: string) => {
+    e?.preventDefault();
+    e?.stopPropagation();
+    try {
+      await deletePostsSave(id);
+      queryClient.invalidateQueries({ queryKey: ["MySavePost"] });
+    } catch {
+      showToast("저장 해제 중 오류가 발생했습니다.", "error");
     }
-  }, [router]);
+  };
 
-  if (isLoading) return <Loader />;
+  if (isLoading) return null;
+
+  if (posts.length === 0) {
+    return (
+      <div className={styles.emptyWrap}>
+        <Empty
+          iconName="illust-result-null"
+          title="저장한 글이 없어요"
+          buttonLabel="자유게시판 둘러보기"
+          onButtonClick={() => router.push(PATH_ROUTES.BOARD)}
+        />
+      </div>
+    );
+  }
 
   return (
     <>
-      <section className={styles.cardContainer}>
-        {posts.length > 0 ? (
-          posts.map((post) => <AllCard key={post.id} post={post} case="saved-posts" hasChip />)
-        ) : (
-          <div className={styles.noResult}>
-            아직 저장한 글이 없어요
-            <Link href="/board">
-              <Button size="m" type="filled-primary">
-                자유게시판 둘러보기
-              </Button>
-            </Link>
-          </div>
-        )}
+      <section className={styles.list}>
+        {posts.map((post) => (
+          <Link key={post.id} href={`${PATH_ROUTES.POST}/${post.id}`} className={styles.itemLink}>
+            <UserItem
+              type="bookMark"
+              showTag
+              tag={POST_TYPE_LABEL[post.type] ?? POST_TYPE_LABEL.NORMAL}
+              postTitle={post.title}
+              body={post.content}
+              commentCount={post.commentCount}
+              nickname={post.author?.name ?? ""}
+              viewCount={post.viewCount.toString()}
+              timeCount={timeAgo(post.createdAt)}
+              bookmarkActive
+              onBookmarkClick={(e?: React.MouseEvent) => handleUnsave(e, post.id)}
+            />
+          </Link>
+        ))}
       </section>
       <section className={styles.pagination}>
         <Pagination

--- a/src/components/UnderlineTabs/UnderlineTabs.module.scss
+++ b/src/components/UnderlineTabs/UnderlineTabs.module.scss
@@ -1,55 +1,53 @@
 @use "@/styles/globals.scss" as *;
+@use "@/styles/breakpoint" as *;
+@use "@/styles/tokens/typography/semantic" as typo;
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/spacing" as spacing;
+@use "@/styles/tokens/radius" as radius;
 
 .navContainer {
   display: flex;
   align-items: center;
-  gap: 20px;
-  border-bottom: 1px solid $gray30;
-  background-color: $gray0;
+  border-bottom: 1px solid colors.$border-gray-subtle;
   position: relative;
-
-  @include Size("mobile") {
-    gap: 16px;
-    padding: 0 16px;
-  }
 
   .underline {
     position: absolute;
     bottom: -1px;
     left: 0;
     height: 2px;
-    background-color: $gray70;
+    background-color: colors.$border-gray-bold;
     transition: all 0.3s ease;
   }
 
   .button {
-    padding: 0 12px 8px;
+    padding: spacing.$spacing-12 spacing.$spacing-12 spacing.$spacing-16;
     background: none;
     border: none;
-    color: $gray60;
-    @include Sub2;
+    color: colors.$text-gray-subtle;
+    @include typo.subtitle-1;
     transition: all 0.3s;
     cursor: pointer;
 
-    @include Size("mobile") {
-      @include Sub4;
-      padding: 0 0 8px;
+    @include breakpoint-down("xs") {
+      @include typo.label-3;
+      padding: spacing.$spacing-12 spacing.$spacing-8 spacing.$spacing-16;
     }
 
     &:hover {
-      color: $gray70;
+      color: colors.$text-gray-normal;
     }
 
     &.selected {
-      color: $gray70;
+      color: colors.$text-gray-bold;
     }
   }
 
   .bar {
     width: 1px;
-    height: 20px;
-    background-color: $gray30;
+    height: spacing.$spacing-20;
+    background-color: colors.$border-gray-bold;
     padding: 0;
-    margin-bottom: 8px;
+    margin-bottom: spacing.$spacing-8;
   }
 }

--- a/src/components/common/Card/Album/Album.module.scss
+++ b/src/components/common/Card/Album/Album.module.scss
@@ -1,9 +1,11 @@
+@use "@/styles/breakpoint" as *;
 @use "@/styles/tokens/colors/semantic" as colors;
 @use "@/styles/tokens/typography/semantic" as typo;
 @use "@/styles/tokens/spacing" as spacing;
 @use "@/styles/tokens/radius" as radius;
 
 .album {
+  width: 100%;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -11,10 +13,16 @@
   overflow: hidden;
 }
 
+.linkPart {
+  display: block;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
 .imageWrap {
   position: relative;
   width: 100%;
-  min-width: 160px;
   aspect-ratio: 1;
   border-radius: radius.$radius-md;
   overflow: hidden;

--- a/src/components/common/Card/Album/Album.tsx
+++ b/src/components/common/Card/Album/Album.tsx
@@ -120,12 +120,12 @@ export default function Album({
       )}
 
       {isMainOrRank && (
-        <span
+        <button
+          type="button"
           className={clsx(styles.iconBottomRight, canLike && styles.iconBottomRightClickable)}
-          role={canLike ? "button" : undefined}
-          tabIndex={canLike ? 0 : undefined}
+          disabled={!canLike}
           aria-pressed={canLike ? isLiked : undefined}
-          aria-label={canLike ? (isLiked ? "좋아요 취소" : "좋아요") : undefined}
+          aria-label={canLike ? (isLiked ? '좋아요 취소' : '좋아요') : undefined}
           onClick={canLike ? blockBubble(handleLikeClick) : undefined}
           onKeyDown={keyDownOnLike}
         >
@@ -134,7 +134,7 @@ export default function Album({
             size={24}
             color={isLiked ? "primary-normal" : "gray-subtle"}
           />
-        </span>
+        </button>
       )}
     </div>
   );

--- a/src/components/common/Card/Album/Album.tsx
+++ b/src/components/common/Card/Album/Album.tsx
@@ -1,22 +1,32 @@
-import { useState } from "react";
+import { useState, type MouseEvent, type ReactNode } from "react";
+import Link from "next/link";
 import clsx from "clsx";
+
 import Icon from "@/components/common/Icon/Icon";
 import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
+import UserInfo from "@/components/common/Cell/UserInfo/UserInfo";
 import {
   useKeyDownActivate,
   useKeyDownActivateStopPropagation,
   useToggleWithCallback,
 } from "@/hooks/useCardInteraction";
+
+import { THUMBNAIL_PATH } from "@/constants/imageUrl";
+
 import styles from "./Album.module.scss";
 import type { AlbumProps, AlbumRank } from "./Album.types";
-import { THUMBNAIL_PATH } from "@/constants/imageUrl";
-import UserInfo from "@/components/common/Cell/UserInfo/UserInfo";
 
 const RANK_ICON_MAP: Record<AlbumRank, "rank-1" | "rank-2" | "rank-3" | "rank-4"> = {
   1: "rank-1",
   2: "rank-2",
   3: "rank-3",
   4: "rank-4",
+};
+
+const blockBubble = (handler: () => void) => (e: MouseEvent) => {
+  e.preventDefault();
+  e.stopPropagation();
+  handler();
 };
 
 export default function Album({
@@ -29,6 +39,7 @@ export default function Album({
   likeCount,
   viewCount,
   isLiked: isLikedProp,
+  linkHref,
   onClick,
   onCheckClick,
   onLikeClick,
@@ -50,118 +61,113 @@ export default function Album({
   const handleLikeClick = useToggleWithCallback(isControlledLiked, setInternalLiked, onLikeClick);
 
   const isCheck = variant === "check";
-  const keyDownOnArticle = useKeyDownActivate(onClick);
-  const keyDownOnCheckWrap = useKeyDownActivateStopPropagation(
-    isCheck && onCheckClick ? handleCheckClick : undefined,
-  );
-  const isRank = variant === "rank" && rank != null && rank in RANK_ICON_MAP;
   const isMainOrRank = variant === "mainTitle" || variant === "rank";
+  const isRank = variant === "rank" && rank != null && rank in RANK_ICON_MAP;
+  const canCheck = isCheck && Boolean(onCheckClick);
+  const canLike = isMainOrRank && Boolean(onLikeClick);
+  const articleOnClick = linkHref ? undefined : onClick;
+
+  const keyDownOnArticle = useKeyDownActivate(articleOnClick);
+  const keyDownOnCheckWrap = useKeyDownActivateStopPropagation(
+    canCheck ? handleCheckClick : undefined,
+  );
+  const keyDownOnLike = useKeyDownActivateStopPropagation(
+    canLike ? handleLikeClick : undefined,
+  );
+
+  const imageNode = (
+    <div
+      className={clsx(
+        styles.imageWrap,
+        isMainOrRank && styles.mainTitleRankOverlay,
+        isCheck && !checked && styles.checkDefault,
+        isCheck && checked && styles.checked,
+        canCheck && styles.imageWrapClickable,
+      )}
+      role={canCheck ? "button" : undefined}
+      tabIndex={canCheck ? 0 : undefined}
+      onClick={canCheck ? blockBubble(handleCheckClick) : undefined}
+      onKeyDown={keyDownOnCheckWrap}
+    >
+      <ResponsiveImage
+        src={imageUrl ?? THUMBNAIL_PATH}
+        alt=""
+        className={styles.image}
+        mobileSize={400}
+        desktopSize={800}
+      />
+
+      {isRank && (
+        <span className={styles.iconTopLeft} aria-hidden>
+          <Icon name={RANK_ICON_MAP[rank!]} size={24} />
+        </span>
+      )}
+
+      {isCheck && (
+        <button
+          type="button"
+          className={styles.iconTopRight}
+          aria-pressed={checked}
+          aria-label={checked ? "선택 해제" : "선택"}
+          onClick={blockBubble(handleCheckClick)}
+        >
+          <Icon
+            name={checked ? "check-square-fill" : "check-square"}
+            size={24}
+            color={checked ? "primary-normal" : "gray-subtler"}
+          />
+        </button>
+      )}
+
+      {isMainOrRank && (
+        <span
+          className={clsx(styles.iconBottomRight, canLike && styles.iconBottomRightClickable)}
+          role={canLike ? "button" : undefined}
+          tabIndex={canLike ? 0 : undefined}
+          aria-pressed={canLike ? isLiked : undefined}
+          aria-label={canLike ? (isLiked ? "좋아요 취소" : "좋아요") : undefined}
+          onClick={canLike ? blockBubble(handleLikeClick) : undefined}
+          onKeyDown={keyDownOnLike}
+        >
+          <Icon
+            name={isLiked ? "heart-fill" : "heart"}
+            size={24}
+            color={isLiked ? "primary-normal" : "gray-subtle"}
+          />
+        </span>
+      )}
+    </div>
+  );
+
+  const titleNode = <p className={styles.title}>{title}</p>;
+
+  const withLink = (node: ReactNode) =>
+    linkHref ? (
+      <Link href={linkHref} className={styles.linkPart}>
+        {node}
+      </Link>
+    ) : (
+      node
+    );
 
   return (
     <article
       className={clsx(styles.album, className)}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onClick={onClick}
+      role={articleOnClick ? "button" : undefined}
+      tabIndex={articleOnClick ? 0 : undefined}
+      onClick={articleOnClick}
       onKeyDown={keyDownOnArticle}
     >
-      <div
-        className={clsx(
-          styles.imageWrap,
-          isMainOrRank && styles.mainTitleRankOverlay,
-          isCheck && !checked && styles.checkDefault,
-          isCheck && checked && styles.checked,
-          isCheck && onCheckClick && styles.imageWrapClickable,
-        )}
-        role={isCheck && onCheckClick ? "button" : undefined}
-        tabIndex={isCheck && onCheckClick ? 0 : undefined}
-        onClick={
-          isCheck && onCheckClick
-            ? (e) => {
-                e.stopPropagation();
-                handleCheckClick();
-              }
-            : undefined
-        }
-        onKeyDown={isCheck && onCheckClick ? keyDownOnCheckWrap : undefined}
-      >
-        <ResponsiveImage
-          src={imageUrl ?? THUMBNAIL_PATH}
-          alt=""
-          className={styles.image}
-          mobileSize={400}
-          desktopSize={800}
-        />
-
-        {isRank && (
-          <span className={styles.iconTopLeft} aria-hidden>
-            <Icon name={RANK_ICON_MAP[rank!]} size={24} />
-          </span>
-        )}
-
-        {isCheck && (
-          <button
-            type="button"
-            className={styles.iconTopRight}
-            aria-pressed={checked}
-            aria-label={checked ? "선택 해제" : "선택"}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleCheckClick();
-            }}
-          >
-            <Icon
-              name={checked ? "check-square-fill" : "check-square"}
-              size={24}
-              color={checked ? "primary-normal" : "gray-subtler"}
-            />
-          </button>
-        )}
-
-        {isMainOrRank && (
-          <span
-            className={clsx(styles.iconBottomRight, onLikeClick && styles.iconBottomRightClickable)}
-            role={onLikeClick ? "button" : undefined}
-            tabIndex={onLikeClick ? 0 : undefined}
-            aria-pressed={onLikeClick ? isLiked : undefined}
-            aria-label={onLikeClick ? (isLiked ? "좋아요 취소" : "좋아요") : undefined}
-            onClick={
-              onLikeClick
-                ? (e) => {
-                    e.stopPropagation();
-                    handleLikeClick();
-                  }
-                : undefined
-            }
-            onKeyDown={
-              onLikeClick
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleLikeClick();
-                    }
-                  }
-                : undefined
-            }
-          >
-            <Icon
-              name={isLiked ? "heart-fill" : "heart"}
-              size={24}
-              color={isLiked ? "primary-normal" : "gray-subtle"}
-            />
-          </span>
-        )}
-      </div>
+      {withLink(imageNode)}
 
       <div className={styles.body}>
-        <p className={styles.title}>{title}</p>
+        {withLink(titleNode)}
         <UserInfo
           type="default"
           nickname={nickname}
-          showHeart={true}
+          showHeart
           heartCount={likeCount.toString()}
-          showView={true}
+          showView
           viewCount={viewCount.toString()}
         />
       </div>

--- a/src/components/common/Card/Album/Album.types.ts
+++ b/src/components/common/Card/Album/Album.types.ts
@@ -11,6 +11,8 @@ export interface AlbumProps {
   likeCount: number;
   viewCount: number;
   isLiked?: boolean;
+  /** 이미지와 타이틀에만 링크를 거는 옵션. 설정 시 onClick은 무시됨 */
+  linkHref?: string;
   onClick?: () => void;
   onCheckClick?: () => void;
   onLikeClick?: () => void;

--- a/src/components/common/Cell/UserItem/UserItem.module.scss
+++ b/src/components/common/Cell/UserItem/UserItem.module.scss
@@ -390,7 +390,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
   min-width: 0;
 }
 

--- a/src/components/common/Navigation/GNB/GNB.tsx
+++ b/src/components/common/Navigation/GNB/GNB.tsx
@@ -213,7 +213,7 @@ export default function GNB({
         >
           <div className={clsx(styles.flexRow, styles.gap8)}>
             <BackButton onClick={onBack} />
-            <span className={styles.title}>{title}</span>
+            {title && <span className={styles.title}>{title}</span>}
           </div>
           <div className={clsx(styles.flexRow, styles.flexPushEnd, styles.gap8)}>
             <SearchButton onClick={onSearch} />
@@ -228,7 +228,7 @@ export default function GNB({
         <nav className={clsx(styles.gnb, styles.gnbTopNav, styles.navGap8, className)}>
           <div className={clsx(styles.flexRow, styles.gap8)}>
             <BackButton onClick={onBack} />
-            <span className={styles.title}>{title}</span>
+            {title && <span className={styles.title}>{title}</span>}
           </div>
           <div className={clsx(styles.flexRow, styles.flexPushEnd, styles.gap8)}>
             {rightActions}

--- a/src/components/common/Navigation/Sidebar/Sidebar.tsx
+++ b/src/components/common/Navigation/Sidebar/Sidebar.tsx
@@ -175,22 +175,30 @@ export default function Sidebar({
     return () => document.removeEventListener("mousedown", onDocMouseDown);
   }, []);
 
+  const resolvedProfileActiveItem = useMemo<"liked" | "saved" | undefined>(() => {
+    if (profileActiveItem) return profileActiveItem;
+    if (router.pathname !== "/mypage") return undefined;
+    if (router.query.tab === "liked-feeds") return "liked";
+    if (router.query.tab === "saved-posts") return "saved";
+    return undefined;
+  }, [profileActiveItem, router.pathname, router.query.tab]);
+
   const profileMenuItems = useMemo(
     () => [
       {
         icon: "heart-fill" as IconName,
         label: "좋아요한 그림",
-        active: profileActiveItem === "liked",
-        onClick: onProfileLikedClick,
+        active: resolvedProfileActiveItem === "liked",
+        onClick: onProfileLikedClick ?? (() => navigate("/mypage?tab=liked-feeds")),
       },
       {
         icon: "bookmark-fill" as IconName,
         label: "저장한 글",
-        active: profileActiveItem === "saved",
-        onClick: onProfileSavedClick,
+        active: resolvedProfileActiveItem === "saved",
+        onClick: onProfileSavedClick ?? (() => navigate("/mypage?tab=saved-posts")),
       },
     ],
-    [profileActiveItem, onProfileLikedClick, onProfileSavedClick],
+    [resolvedProfileActiveItem, onProfileLikedClick, onProfileSavedClick, navigate],
   );
 
   const openExternal = useCallback(

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -17,14 +17,10 @@ export default function Mypage() {
     switch (tab) {
       case "liked-feeds":
         return "좋아요한 그림";
-      case "saved-feeds":
-        return "저장한 그림";
-      case "liked-posts":
-        return "좋아요한 글";
-      case "my-comments":
-        return "내가 쓴 댓글";
+      case "saved-posts":
+        return "저장한 글";
       default:
-        return "마이페이지";
+        return "내 보관함";
     }
   };
 


### PR DESCRIPTION
### 🔎 작업 내용

- [x]  내 보관함: 좋아요한 그림 / 저장한 글 두 탭만 노출 (저장한 그림 탭 제거)
- [x]  `LikedFeeds` 디자인시스템 마이그레이션
   * `ProfileCard` → `Album`, 빈 상태 → `Empty`, 무한 스크롤은 `useInfiniteScroll` 훅 활용, 로딩은 `useGlobalLoading`로 전역화
- [x]  `SavedPosts` 디자인시스템 마이그레이션
   * `AllCard` → `UserItem(type="bookMark")`, 빈 상태 → `Empty`, 북마크 토글로 저장 해제, 페이지네이션 유지
- [x]  `Album` 컴포넌트에 `linkHref` prop 추가
   * 설정 시 카드 전체가 아닌 이미지·타이틀에만 Link가 걸림 (좋아요/체크 클릭은 `preventDefault`로 네비게이션 차단)
- [x]  `Album` 내부 코드 정리: `blockBubble` 헬퍼로 중복 클릭 핸들러 통합, 인라인 keydown → `useKeyDownActivateStopPropagation` 훅 일원화, 조건식 변수화 (`canCheck`/`canLike`)
- [x]  모바일 마이페이지 GNB를 `depth-2` 변형으로 전환 (Layout `gnbVariant` 분기 추가)
- [x]  `GNB`의 `title`을 nullable 처리
   * `depth-2`/`three-button`
- [x]  `Sidebar` 프로필 메뉴(좋아요한 그림/저장한 글) 클릭 → mypage 탭으로 이동하도록 기본 동작 추가. 현재 라우트(`?tab=`) 기반으로 active 상태 자동 추론
- [x]  `Layout`의 PC TopButton 및 관련 코드(scroll 리스너, `SCROLL_TOP_THRESHOLD`, `isScrollAbove` state) 제거
- [x]  `UnderlineTabs` / `MyPage` / `UserItem` SCSS를 디자인 토큰(`@/styles/tokens/*`, `@/styles/breakpoint`)으로 마이그레이션, 레거시 `Size("mobile")` / `$gray*` 변수 제거

### 📸 스크린샷
<img width="1427" height="1043" alt="image" src="https://github.com/user-attachments/assets/71631701-ebc4-49b1-b9a9-ded5e1c7c945" />
<img width="1172" height="1002" alt="image" src="https://github.com/user-attachments/assets/299e955d-1f83-41ad-9269-b0aa9e15df6b" />
<img width="400" height="856" alt="image" src="https://github.com/user-attachments/assets/ecf5c708-4223-4a5c-8bec-54191bb7a359" /><img width="404" height="860" alt="image" src="https://github.com/user-attachments/assets/1bd556be-3ac3-42b8-80a1-95af9c037699" />
<img width="668" height="961" alt="image" src="https://github.com/user-attachments/assets/5bfebf5d-7abc-47c8-b179-fcc44b00f78b" />



### :loudspeaker: 전달사항

- Album.linkHref는 신규 옵셔널 prop이라 NewFeed/Ranking 등 기존 사용처는 영향 없음. linkHref를 안 쓰는 경우 기존처럼 onClick 동작
