### PR TITLE
[Fix] 메인 카드 비로그인 시 좋아요 버튼 숨김

### DIFF
--- a/src/components/Layout/MainBoard/MainBoard.tsx
+++ b/src/components/Layout/MainBoard/MainBoard.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { usePostsLatest, usePostsNotices } from "@/api/posts/getPosts";
 import { useGlobalLoading } from "@/hooks/useGlobalLoading";
 
-import BoardCard from "../BoardCard/BoardCard";
+import BoardCard from "@/components/Layout/BoardCard/BoardCard";
 import Title from "@/components/Layout/Title/Title";
 import Divider from "@/components/common/Divider/Divider";
 

--- a/src/components/Layout/NewFeed/NewFeed.tsx
+++ b/src/components/Layout/NewFeed/NewFeed.tsx
@@ -67,9 +67,11 @@ export default function NewFeed({ isDetail = false }: NewFeedProps) {
                   nickname={feed.author?.name ?? ""}
                   likeCount={feed.likeCount}
                   viewCount={feed.viewCount}
-                  isLiked={isLiked}
+                  isLiked={isLoggedIn ? isLiked : undefined}
                   onLikeClick={
-                    isLoggedIn ? () => toggleLike({ id: feed.id, isLiked }) : undefined
+                    isLoggedIn
+                      ? () => toggleLike({ id: feed.id, isLiked })
+                      : undefined
                   }
                 />
               </Link>

--- a/src/components/Layout/Ranking/Ranking.tsx
+++ b/src/components/Layout/Ranking/Ranking.tsx
@@ -90,9 +90,11 @@ export default function Ranking() {
                       nickname={feed.author?.name ?? ""}
                       likeCount={feed.likeCount}
                       viewCount={feed.viewCount}
-                      isLiked={isLiked}
+                      isLiked={isLoggedIn ? isLiked : undefined}
                       onLikeClick={
-                        isLoggedIn ? () => toggleLike({ id: feed.id, isLiked }) : undefined
+                        isLoggedIn
+                          ? () => toggleLike({ id: feed.id, isLiked })
+                          : undefined
                       }
                     />
                   </Link>

--- a/src/components/common/Card/Album/Album.module.scss
+++ b/src/components/common/Card/Album/Album.module.scss
@@ -94,6 +94,9 @@
 
   &.iconBottomRightClickable {
     pointer-events: auto;
+    border: none;
+    background: transparent;
+    padding: 0;
     cursor: pointer;
   }
 }

--- a/src/components/common/Card/Album/Album.tsx
+++ b/src/components/common/Card/Album/Album.tsx
@@ -118,39 +118,24 @@ export default function Album({
           </button>
         )}
 
-        {isMainOrRank && (
-          <span
-            className={clsx(styles.iconBottomRight, onLikeClick && styles.iconBottomRightClickable)}
-            role={onLikeClick ? "button" : undefined}
-            tabIndex={onLikeClick ? 0 : undefined}
-            aria-pressed={onLikeClick ? isLiked : undefined}
-            aria-label={onLikeClick ? (isLiked ? "좋아요 취소" : "좋아요") : undefined}
-            onClick={
-              onLikeClick
-                ? (e) => {
-                    e.stopPropagation();
-                    handleLikeClick();
-                  }
-                : undefined
-            }
-            onKeyDown={
-              onLikeClick
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleLikeClick();
-                    }
-                  }
-                : undefined
-            }
+        {isMainOrRank && onLikeClick && (
+          <button
+            type="button"
+            className={clsx(styles.iconBottomRight, styles.iconBottomRightClickable)}
+            aria-pressed={isLiked}
+            aria-label={isLiked ? "좋아요 취소" : "좋아요"}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleLikeClick();
+            }}
           >
             <Icon
               name={isLiked ? "heart-fill" : "heart"}
               size={24}
               color={isLiked ? "primary-normal" : "gray-subtle"}
             />
-          </span>
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 메인 최신 그림(NewFeed), 주간 랭킹(Ranking) 카드에서 비로그인 시 이미지 위 하트(좋아요) 버튼 미노출
- [x] Album은 onLikeClick이 있을 때만 하트 버튼 렌더링 (<button>으로 변경, Link 이동 방지)
- [x] MainBoard의 BoardCard import 경로 @/ alias로 정리

### 📸 스크린샷

### 기존 (하트 버튼 클릭 시 해당 그림 상세 페이지로 이동)
<img width="1325" height="1416" alt="image" src="https://github.com/user-attachments/assets/299f61f5-395d-4bb1-90a4-c4a102728ce7" />

### 수정 후 비로그인 시
<img width="1331" height="1414" alt="image" src="https://github.com/user-attachments/assets/0ee59392-0851-4376-bd9d-e0f25b5fc719" />

### 수정 후 로그인 시
<img width="1329" height="1416" alt="image" src="https://github.com/user-attachments/assets/528d4c0a-0628-43e8-bcdb-c73978fe1dbb" />
