### PR TITLE
[Feature] 디자인 시스템 반영(검색)

### DIFF
--- a/src/components/SearchPage/Feed/SearchFeed/SearchFeed.module.scss
+++ b/src/components/SearchPage/Feed/SearchFeed/SearchFeed.module.scss
@@ -18,8 +18,12 @@
   column-gap: spacing.$spacing-16;
   row-gap: spacing.$spacing-24;
 
-  @include bp.breakpoint-down("sm") {
+  @include bp.breakpoint-down("md") {
     grid-template-columns: repeat(4, 1fr);
+  }
+
+  @include bp.breakpoint-down("sm") {
+    grid-template-columns: repeat(3, 1fr);
   }
 
   @include bp.breakpoint-down("xs") {

--- a/src/components/SearchPage/Feed/SearchFeed/SearchFeed.tsx
+++ b/src/components/SearchPage/Feed/SearchFeed/SearchFeed.tsx
@@ -13,7 +13,37 @@ import Empty from "@/components/common/Empty/Empty";
 import SearchHighlightText from "@/components/SearchPage/SearchHighlightText/SearchHighlightText";
 import { resolveSortOption } from "@/components/SearchPage/searchPage.constants";
 
+import type { SearchedFeedsResponse } from "@grimity/dto";
+
 import styles from "./SearchFeed.module.scss";
+
+type SearchFeedItemData = SearchedFeedsResponse["feeds"][number];
+
+type SearchFeedItemProps = {
+  feed: SearchFeedItemData;
+  keyword: string;
+  isLoggedIn: boolean;
+  onLikeClick: (id: string, isLiked: boolean) => void;
+};
+
+function SearchFeedItem({ feed, keyword, isLoggedIn, onLikeClick }: SearchFeedItemProps) {
+  const isLiked = feed.isLike ?? false;
+
+  return (
+    <Link href={`/feeds/${feed.id}`} className={styles.cardLink}>
+      <Album
+        variant="mainTitle"
+        imageUrl={feed.thumbnail}
+        title={<SearchHighlightText text={feed.title} keyword={keyword} />}
+        nickname={feed.author?.name ?? ""}
+        likeCount={feed.likeCount}
+        viewCount={feed.viewCount}
+        isLiked={isLiked}
+        onLikeClick={isLoggedIn ? () => onLikeClick(feed.id, isLiked) : undefined}
+      />
+    </Link>
+  );
+}
 
 export default function SearchFeed() {
   const router = useRouter();
@@ -53,6 +83,10 @@ export default function SearchFeed() {
 
   const hasResults = data?.pages.some((page) => page.feeds.length > 0) ?? false;
 
+  const handleLikeClick = (id: string, isLiked: boolean) => {
+    toggleLike({ id, isLiked });
+  };
+
   if (isLoading) return null;
 
   return (
@@ -67,25 +101,15 @@ export default function SearchFeed() {
       ) : (
         <div className={styles.grid}>
           {data?.pages.map((page) =>
-            page.feeds.map((feed) => {
-              const isLiked = feed.isLike ?? false;
-              return (
-                <Link key={feed.id} href={`/feeds/${feed.id}`} className={styles.cardLink}>
-                  <Album
-                    variant="mainTitle"
-                    imageUrl={feed.thumbnail}
-                    title={<SearchHighlightText text={feed.title} keyword={keyword} />}
-                    nickname={feed.author?.name ?? ""}
-                    likeCount={feed.likeCount}
-                    viewCount={feed.viewCount}
-                    isLiked={isLiked}
-                    onLikeClick={
-                      isLoggedIn ? () => toggleLike({ id: feed.id, isLiked }) : undefined
-                    }
-                  />
-                </Link>
-              );
-            }),
+            page.feeds.map((feed) => (
+              <SearchFeedItem
+                key={feed.id}
+                feed={feed}
+                keyword={keyword}
+                isLoggedIn={isLoggedIn}
+                onLikeClick={handleLikeClick}
+              />
+            )),
           )}
         </div>
       )}

--- a/src/components/SearchPage/Post/SearchPost/SearchPost.tsx
+++ b/src/components/SearchPage/Post/SearchPost/SearchPost.tsx
@@ -36,12 +36,14 @@ const POST_TYPE_LABEL: Record<PostType, string> = {
 const PAGE_SIZE = 10;
 const SAVED_POSTS_LOOKUP_SIZE = 100;
 
+const domParser = typeof window !== "undefined" ? new DOMParser() : null;
+
 function plainPreviewFromContent(html: string | null | undefined): string | undefined {
   if (!html?.trim()) return undefined;
   const stripped = html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
   if (!stripped) return undefined;
-  if (typeof window === "undefined") return stripped;
-  return new DOMParser().parseFromString(stripped, "text/html").documentElement.textContent ?? stripped;
+  if (!domParser) return stripped;
+  return domParser.parseFromString(stripped, "text/html").documentElement.textContent ?? stripped;
 }
 
 type SearchPostItemProps = {

--- a/src/components/SearchPage/SearchPage.module.scss
+++ b/src/components/SearchPage/SearchPage.module.scss
@@ -82,18 +82,6 @@
   width: 100%;
   max-width: 900px;
   min-width: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: spacing.$spacing-16;
-  border-bottom: 1px solid colors.$border-gray-subtle;
-}
-
-.tabs {
-  display: flex;
-  align-items: center;
-  gap: spacing.$spacing-8;
-  min-width: 0;
 }
 
 .sortMenu {
@@ -131,41 +119,6 @@
   width: 100%;
   max-width: 900px;
   min-width: 0;
-}
-
-.tab {
-  padding: spacing.$spacing-12 spacing.$spacing-12 spacing.$spacing-16 spacing.$spacing-12;
-  background: none;
-  border: none;
-  cursor: pointer;
-  @include typo.subtitle-1;
-  color: colors.$text-gray-subtle;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition: color 0.15s ease, border-color 0.15s ease;
-
-  &:hover {
-    color: colors.$text-gray-normal;
-  }
-
-  @include bp.breakpoint-down("sm") {
-    padding: spacing.$spacing-12 spacing.$spacing-10 spacing.$spacing-16 spacing.$spacing-10;
-    @include typo.label-1;
-  }
-
-  @include bp.breakpoint-down("xs") {
-    padding: spacing.$spacing-12 spacing.$spacing-8 spacing.$spacing-16 spacing.$spacing-8;
-    @include typo.label-3;
-  }
-}
-
-.tabActive {
-  color: colors.$text-gray-bold;
-  border-bottom-color: colors.$border-gray-bold;
-
-  &:hover {
-    color: colors.$text-gray-bold;
-  }
 }
 
 .emptyContainer{

--- a/src/components/SearchPage/SearchPage.tsx
+++ b/src/components/SearchPage/SearchPage.tsx
@@ -6,7 +6,7 @@ import { useDeviceStore } from "@/states/deviceStore";
 
 import Empty from "@/components/common/Empty/Empty";
 import Icon from "@/components/common/Icon/Icon";
-import Menu from "@/components/common/Navigation/Menu/Menu";
+import Filter from "@/components/common/Filter/Filter";
 import BottomSheet from "@/components/common/PopUp/BottomSheet/BottomSheet";
 import TextField from "@/components/common/Input/TextField/TextField";
 import { useToast } from "@/hooks/useToast";
@@ -15,6 +15,7 @@ import SearchFeed from "./Feed/SearchFeed/SearchFeed";
 import SearchAuthor from "./User/SearchAuthor/SearchAuthor";
 import SearchPost from "./Post/SearchPost/SearchPost";
 import RecommendTagsSlider from "./RecommendTagsSlider/RecommendTagsSlider";
+import UnderlineTabs from "@/components/UnderlineTabs/UnderlineTabs";
 import {
   type Tab,
   SORT_OPTIONS_BY_TAB,
@@ -28,10 +29,10 @@ import clsx from "clsx";
 
 const POPULAR_TAG_LIMIT = 10;
 
-const TABS: { value: Tab; label: string }[] = [
-  { value: "feed", label: "그림" },
-  { value: "author", label: "작가" },
-  { value: "board", label: "자유게시판" },
+const TABS: { key: Tab; label: string }[] = [
+  { key: "feed", label: "그림" },
+  { key: "author", label: "작가" },
+  { key: "board", label: "자유게시판" },
 ];
 
 export default function SearchPage() {
@@ -127,23 +128,36 @@ export default function SearchPage() {
     }
   };
 
-  const sortTriggerButton = (
-    <button
-      type="button"
-      className={clsx(styles.sortTrigger, !queryKeyword && styles.disabled)}
-      disabled={!queryKeyword}
-      aria-haspopup={isMobile ? "dialog" : "menu"}
-      aria-label="정렬 기준 선택"
-      onClick={isMobile ? () => setIsSortSheetOpen(true) : undefined}
-    >
-      <span>{selectedSortLabel}</span>
-      <Icon
-        name="chevron-down"
-        size={16}
-        color={!queryKeyword ? "gray-subtler" : "gray-bold"}
-      />
-    </button>
-  );
+  const sortMenu =
+    tab !== "author" ? (
+      <div className={styles.sortMenu}>
+        {isMobile ? (
+          <button
+            type="button"
+            className={clsx(styles.sortTrigger, !queryKeyword && styles.disabled)}
+            disabled={!queryKeyword}
+            aria-haspopup="dialog"
+            aria-label="정렬 기준 선택"
+            onClick={() => setIsSortSheetOpen(true)}
+          >
+            <span>{selectedSortLabel}</span>
+            <Icon
+              name="chevron-down"
+              size={16}
+              color={!queryKeyword ? "gray-subtler" : "gray-bold"}
+            />
+          </button>
+        ) : (
+          <Filter
+            variant="text"
+            options={sortOptions}
+            value={sort}
+            onChange={handleSortChange}
+            disabled={!queryKeyword}
+          />
+        )}
+      </div>
+    ) : undefined;
 
   return (
     <div className={styles.container}>
@@ -161,7 +175,7 @@ export default function SearchPage() {
         </div>
         {popularData &&
           popularData.length > 0 &&
-          !(isMobile && queryKeyword) && (
+          !(isMobile && !!queryKeyword) && (
             <div className={styles.recommend}>
               <div className={styles.recommendInner}>
                 <p className={styles.recommendLabel}>추천 태그</p>
@@ -172,42 +186,17 @@ export default function SearchPage() {
       </section>
 
       <div className={styles.tabPanel}>
-        {(!isMobile || queryKeyword) && <div className={styles.tabBar}>
-          <nav className={styles.tabs} aria-label="검색 카테고리">
-            {TABS.map((t) => {
-              const isActive = tab === t.value;
-              return (
-                <button
-                  key={t.value}
-                  type="button"
-                  className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
-                  onClick={() => navigateSearch(queryKeyword, t.value)}
-                  aria-pressed={isActive}
-                >
-                  {t.label}
-                </button>
-              );
-            })}
-          </nav>
-
-          {tab !== "author" && (
-            <div className={styles.sortMenu}>
-              {isMobile ? (
-                sortTriggerButton
-              ) : (
-                <Menu
-                  align="right"
-                  trigger={sortTriggerButton}
-                  items={sortOptions.map((option) => ({
-                    label: option.label,
-                    selected: option.value === sort,
-                    onClick: () => handleSortChange(option.value),
-                  }))}
-                />
-              )}
-            </div>
-          )}
-        </div>}
+        {(!isMobile || !!queryKeyword) && (
+          <div className={styles.tabBar}>
+            <UnderlineTabs
+              tabs={TABS}
+              activeTab={tab}
+              onTabChange={(key) => navigateSearch(queryKeyword, key)}
+              ariaLabel="검색 카테고리"
+              rightSlot={sortMenu}
+            />
+          </div>
+        )}
 
         <div className={styles.tabContent}>{renderTab()}</div>
       </div>

--- a/src/components/UnderlineTabs/UnderlineTabs.module.scss
+++ b/src/components/UnderlineTabs/UnderlineTabs.module.scss
@@ -5,6 +5,26 @@
 @use "@/styles/tokens/spacing" as spacing;
 @use "@/styles/tokens/radius" as radius;
 
+.barContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: spacing.$spacing-16;
+  width: 100%;
+  min-width: 0;
+  border-bottom: 1px solid colors.$border-gray-subtle;
+
+  .navContainer {
+    flex: 1;
+    min-width: 0;
+    border-bottom: none;
+  }
+}
+
+.rightSlot {
+  flex-shrink: 0;
+}
+
 .navContainer {
   display: flex;
   align-items: center;

--- a/src/components/UnderlineTabs/UnderlineTabs.tsx
+++ b/src/components/UnderlineTabs/UnderlineTabs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import styles from "./UnderlineTabs.module.scss";
 import React from "react";
 
@@ -12,12 +12,16 @@ interface UnderlineTabsProps<T extends string> {
   tabs: TabItem<T>[];
   activeTab: T;
   onTabChange: (tabKey: T) => void;
+  rightSlot?: ReactNode;
+  ariaLabel?: string;
 }
 
 export default function UnderlineTabs<T extends string>({
   tabs,
   activeTab,
   onTabChange,
+  rightSlot,
+  ariaLabel,
 }: UnderlineTabsProps<T>) {
   const tabsRef = useRef<(HTMLButtonElement | null)[]>([]);
   const [underlineStyle, setUnderlineStyle] = useState({});
@@ -46,11 +50,14 @@ export default function UnderlineTabs<T extends string>({
     };
   }, [activeTab, tabs]);
 
-  return (
-    <div className={styles.navContainer}>
+  const nav = (
+    <div className={styles.navContainer} role="tablist" aria-label={ariaLabel}>
       {tabs.map((tab, index) => (
         <React.Fragment key={tab.key}>
           <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.key}
             ref={(el) => {
               tabsRef.current[index] = el;
             }}
@@ -63,6 +70,15 @@ export default function UnderlineTabs<T extends string>({
         </React.Fragment>
       ))}
       <div className={styles.underline} style={underlineStyle} />
+    </div>
+  );
+
+  if (!rightSlot) return nav;
+
+  return (
+    <div className={styles.barContainer}>
+      {nav}
+      <div className={styles.rightSlot}>{rightSlot}</div>
     </div>
   );
 }

--- a/src/components/common/Filter/Filter.module.scss
+++ b/src/components/common/Filter/Filter.module.scss
@@ -69,37 +69,3 @@
 .label {
   white-space: nowrap;
 }
-
-.dropdown {
-  position: absolute;
-  top: calc(100% + spacing.$spacing-8);
-  left: 0;
-  z-index: 10;
-  min-width: 100%;
-  margin: 0;
-  padding: spacing.$spacing-8 0;
-  list-style: none;
-  background-color: colors.$surface-base;
-  border-radius: radius.$radius-lg;
-  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.12);
-}
-
-.option {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: spacing.$spacing-12;
-  padding: spacing.$spacing-12 spacing.$spacing-20;
-  cursor: pointer;
-  @include typo.label-3;
-  color: colors.$text-gray-bold;
-  white-space: nowrap;
-
-  &:hover {
-    background-color: colors.$surface-gray-subtlest;
-  }
-
-  &.selected {
-    color: colors.$text-primary-normal;
-  }
-}

--- a/src/components/common/Filter/Filter.tsx
+++ b/src/components/common/Filter/Filter.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import clsx from "clsx";
 import Icon from "@/components/common/Icon/Icon";
+import Menu from "@/components/common/Navigation/Menu/Menu";
 import styles from "./Filter.module.scss";
 import { FilterProps } from "./Filter.types";
 
@@ -11,88 +12,39 @@ export default function Filter({
   onChange,
   disabled = false,
   className,
+  align = "right",
 }: FilterProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
   const selectedOption = options.find((opt) => opt.value === value);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
+  const menuItems = options.map((option) => ({
+    label: option.label,
+    selected: option.value === value,
+    onClick: () => onChange(option.value),
+  }));
 
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isOpen]);
-
-  const handleToggle = () => {
-    if (!disabled) {
-      setIsOpen((prev) => !prev);
-    }
-  };
-
-  const handleSelect = (optionValue: string) => {
-    onChange(optionValue);
-    setIsOpen(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape") {
-      setIsOpen(false);
-    }
-  };
+  const trigger = (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-expanded={isOpen}
+      aria-haspopup="menu"
+      className={clsx(styles.filter, styles[variant])}
+    >
+      <span className={styles.label}>{selectedOption?.label}</span>
+      <Icon name={isOpen ? "chevron-up" : "chevron-down"} size={16} />
+    </button>
+  );
 
   return (
-    <div
-      ref={wrapperRef}
-      className={clsx(styles.wrapper, className)}
-      onKeyDown={handleKeyDown}
-    >
-      <button
-        type="button"
-        disabled={disabled}
-        aria-expanded={isOpen}
-        aria-haspopup="listbox"
-        className={clsx(styles.filter, styles[variant])}
-        onClick={handleToggle}
-      >
-        <span className={styles.label}>{selectedOption?.label}</span>
-        <Icon name={isOpen ? "chevron-up" : "chevron-down"} size={16} />
-      </button>
-      {isOpen && (
-        <ul role="listbox" className={styles.dropdown}>
-          {options.map((option) => {
-            const isSelected = option.value === value;
-            return (
-              <li
-                key={option.value}
-                role="option"
-                aria-selected={isSelected}
-                className={clsx(styles.option, {
-                  [styles.selected]: isSelected,
-                })}
-                onClick={() => handleSelect(option.value)}
-              >
-                <span>{option.label}</span>
-                {isSelected && (
-                  <Icon name="check" size={20} color="primary-normal" />
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </div>
+    <Menu
+      trigger={trigger}
+      items={menuItems}
+      align={align}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      disabled={disabled}
+      wrapperClassName={clsx(styles.wrapper, className)}
+    />
   );
 }

--- a/src/components/common/Filter/Filter.types.ts
+++ b/src/components/common/Filter/Filter.types.ts
@@ -12,4 +12,5 @@ export interface FilterProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   className?: string;
+  align?: "left" | "right";
 }

--- a/src/components/common/Navigation/Menu/Menu.module.scss
+++ b/src/components/common/Navigation/Menu/Menu.module.scss
@@ -8,6 +8,11 @@
   display: inline-block;
 }
 
+.triggerWrap {
+  display: inline-flex;
+  cursor: pointer;
+}
+
 .menuContainer {
   position: absolute;
   top: calc(100% + spacing.$spacing-8);

--- a/src/components/common/Navigation/Menu/Menu.tsx
+++ b/src/components/common/Navigation/Menu/Menu.tsx
@@ -5,9 +5,27 @@ import Icon from "@/components/common/Icon/Icon";
 import styles from "./Menu.module.scss";
 import { MenuProps } from "./Menu.types";
 
-export default function Menu({ items, trigger, align = "right", className }: MenuProps) {
-  const [open, setOpen] = useState(false);
+export default function Menu({
+  items,
+  trigger,
+  align = "right",
+  className,
+  wrapperClassName,
+  open: openProp,
+  onOpenChange,
+  disabled = false,
+}: MenuProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : internalOpen;
+
+  const setOpen = (next: boolean) => {
+    if (!isControlled) {
+      setInternalOpen(next);
+    }
+    onOpenChange?.(next);
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -27,6 +45,10 @@ export default function Menu({ items, trigger, align = "right", className }: Men
     };
   }, [open]);
 
+  const closeMenu = () => {
+    if (trigger) setOpen(false);
+  };
+
   const list = (
     <ul className={clsx(styles.menu, className)} role="menu">
       {items.map((item, i) => (
@@ -37,13 +59,13 @@ export default function Menu({ items, trigger, align = "right", className }: Men
             className={clsx(styles.item, item.selected && styles.itemSelected)}
             onClick={() => {
               item.onClick?.();
-              if (trigger) setOpen(false);
+              closeMenu();
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 item.onClick?.();
-                if (trigger) setOpen(false);
+                closeMenu();
               }
             }}
           >
@@ -64,12 +86,16 @@ export default function Menu({ items, trigger, align = "right", className }: Men
 
   if (!trigger) return list;
 
+  if (disabled) {
+    return <div className={clsx(styles.wrapper, wrapperClassName)}>{trigger}</div>;
+  }
+
   return (
-    <div ref={wrapperRef} className={styles.wrapper}>
-      <div onClick={() => setOpen((prev) => !prev)}>{trigger}</div>
-      {open && (
-        <div className={clsx(styles.menuContainer, styles[align])}>{list}</div>
-      )}
+    <div ref={wrapperRef} className={clsx(styles.wrapper, wrapperClassName)}>
+      <div className={styles.triggerWrap} onClick={() => setOpen(!open)}>
+        {trigger}
+      </div>
+      {open && <div className={clsx(styles.menuContainer, styles[align])}>{list}</div>}
     </div>
   );
 }

--- a/src/components/common/Navigation/Menu/Menu.types.ts
+++ b/src/components/common/Navigation/Menu/Menu.types.ts
@@ -11,5 +11,11 @@ export interface MenuProps {
   items: MenuItem[];
   trigger?: React.ReactNode;
   align?: "left" | "right";
+  /** Menu 패널(`ul`)에 적용 */
   className?: string;
+  /** wrapper div에 적용 */
+  wrapperClassName?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  disabled?: boolean;
 }


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 검색 페이지 디자인시스템 컴포넌트로 교체 (탭/정렬/카드/검색바)
- [x] 모바일(xs) 반응형 대응 (GNB search variant + 정렬 BottomSheet)
- [x] 추천 태그 슬라이더 / 검색어 하이라이트 추가
- [x] 좋아요·팔로우·저장 버튼 동작 정상화 (Link 버블링 차단 + 낙관적 업데이트)
- [x] 카드 좋아요 하트 디자인 변경 (빨강 활성 + 흰색 채움 비활성)
- [x] 작가 탭에선 정렬 메뉴 숨김

### 📸 스크린샷

### PC
<img width="1331" height="1027" alt="image" src="https://github.com/user-attachments/assets/6d729933-a338-418c-adb5-c1f49e22d22b" />
<img width="1333" height="1028" alt="image" src="https://github.com/user-attachments/assets/52610f43-274c-41aa-8bd5-105a1cad1aad" />
<img width="1333" height="1027" alt="image" src="https://github.com/user-attachments/assets/5fa3b491-bcfc-4613-af09-3b61b645ae69" />
<img width="1331" height="1026" alt="image" src="https://github.com/user-attachments/assets/34543f89-b2e1-4d5c-9728-3f36fd052b93" />
<img width="457" height="906" alt="image" src="https://github.com/user-attachments/assets/291d929e-22b8-495e-b51c-098c2be246bc" /><img width="443" height="904" alt="image" src="https://github.com/user-attachments/assets/48312964-6a71-4b0b-a532-d53b2148639e" />


### :loudspeaker: 전달사항

- **Layout 변경**: `/search` + 모바일일 때 GNB `variant="search"`로 전환됩니다. 검색 입력 상태/핸들러는 신규 `useMobileSearchHeader` 훅이 관리합니다.
- **낙관적 업데이트 추가 캐시**: `FeedSearch`(useFeedsLikeMutation), `UserSearch`(usePutFollow/useDeleteFollow), `PostSearch`/`Postsdetails`(usePostsSaveMutation). 클릭 즉시 UI가 반영되고 실패 시 자동 롤백됩니다.
- **GNB 확장**: search variant에 `onSearchKeyDown` / `onSearchClear` prop을 추가했습니다 (기존 사용처 영향 없음)
- **인증 가드**: 검색/저장 목록 쿼리(`PostSearch`, `MySavePost`)가 `isAuthReady`까지 기다리고, `PostSearch`는 `isLoggedIn`을 queryKey에 포함해 로그인 직후 isSave 상태가 정확히 반영됩니다.