### PR TITLE
[Fix] 비로그인 상태에서 Album 좋아요 버튼 노출 수정

### DIFF
--- a/src/components/common/Card/Album/Album.tsx
+++ b/src/components/common/Card/Album/Album.tsx
@@ -125,7 +125,7 @@ export default function Album({
         </button>
       )}
 
-      {isMainOrRank && (
+      {canLike && (
         <button
           type="button"
           className={clsx(


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 비로그인 상태에서 Album 카드(피드 썸네일)에 좋아요 버튼이 그대로 노출되는 이슈 발견 후 좋아요 버튼 렌더 조건을 변경했습니다.
  * 비로그인 시에는 `onLikeClick`이 전달되지 않아 `disabled` 처리만 될 뿐, 하트 아이콘 자체는 계속 보이는 상태였습니다.

### 📸 스크린샷
### 이슈 상황 (비로그인)
<img width="1008" height="389" alt="image" src="https://github.com/user-attachments/assets/b34f1ca1-3594-4f74-b175-92f333690cfc" />

### 이슈 해결 (비로그인)
<img width="1010" height="381" alt="image" src="https://github.com/user-attachments/assets/4cb2031e-836f-415b-97c6-4398ed7915bb" />

### 이슈 해결 (로그인)
<img width="1024" height="378" alt="image" src="https://github.com/user-attachments/assets/3232feb2-668e-4562-8a41-9b0efa6947e5" />


### :loudspeaker: 전달사항

- Album 소비자(SearchFeed / NewFeed / Ranking / LikedFeeds) 모두 `onLikeClick`을 `isLoggedIn`으로 게이팅하고 있어, 이 한 줄 변경으로 전 영역이 일관되게 처리됩니다. `isMainOrRank`는 이미지 오버레이 클래스(`mainTitleRankOverlay`)에서 계속 사용되어 미사용 경고도 없습니다.