### PR TITLE
[Fix] 좋아요 하트 활성 색상 복구

### DIFF
--- a/src/components/common/Card/Album/Album.tsx
+++ b/src/components/common/Card/Album/Album.tsx
@@ -152,7 +152,6 @@ export default function Album({
               name={isLiked ? "heart-fill" : "heart"}
               size={24}
               className={styles.heartStackFg}
-              color={isLiked ? "primary-normal" : "gray-subtle"}
             />
           </span>
         </button>


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 좋아요(하트) 활성 색상이 의도한 빨강(`$status-negative`)이 아니라 초록(`primary-normal`)으로 표시됩니다.
  * 이전에 빨강으로 수정(`1e0ea64`)했으나, 이후 Album 재설계 과정에서 하트 Icon에 인라인 `color` prop이 다시 추가되면서 회귀
  * 하트(foreground) Icon의 인라인 `color` prop을 제거하여 해결


### 📸 스크린샷
<img width="1053" height="342" alt="image" src="https://github.com/user-attachments/assets/d0fd8550-1462-4ef4-9688-fcf9cd508892" />

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항
