### PR TITLE
[Feature] 디자인 시스템 반영(신고하기)

### DIFF
--- a/src/components/Board/Detail/Comment/Comment.tsx
+++ b/src/components/Board/Detail/Comment/Comment.tsx
@@ -11,6 +11,7 @@ import { linkifyText } from "@/utils/linkifyText";
 import IconComponent from "@/components/Asset/Icon";
 import Button from "@/components/Button/Button";
 import { useModalStore } from "@/states/modalStore";
+import { useReportModal } from "@/hooks/useReportModal";
 import TextArea from "@/components/TextArea/TextArea";
 import {
   deletePostsCommentLike,
@@ -24,7 +25,6 @@ import {
 } from "@/api/posts-comments/getPostsComments";
 import { PostCommentProps, PostCommentWriter } from "./Comment.types";
 import { useRouter } from "next/router";
-import { useDeviceStore } from "@/states/deviceStore";
 
 type ToastType = "success" | "error" | "warning" | "information";
 
@@ -80,6 +80,7 @@ export default function PostComment({ postId, postWriterId }: PostCommentProps) 
   const user_id = useAuthStore((state) => state.user_id);
   const { showToast } = useToast();
   const openModal = useModalStore((state) => state.openModal);
+  const openReportModal = useReportModal();
   const queryClient = useQueryClient();
   const [comment, setComment] = useState("");
   const [replyText, setReplyText] = useState("");
@@ -94,7 +95,6 @@ export default function PostComment({ postId, postWriterId }: PostCommentProps) 
   const { mutateAsync: postComment, isPending: isPostCommentPending } = usePostPostsComments();
   const [activeParentReplyId, setActiveParentReplyId] = useState<string | null>(null);
   const [activeChildReplyId, setActiveChildReplyId] = useState<string | null>(null);
-  const { isMobile } = useDeviceStore();
   const { pathname } = useRouter();
 
   useEffect(() => {
@@ -197,18 +197,7 @@ export default function PostComment({ postId, postWriterId }: PostCommentProps) 
       return;
     }
 
-    if (isMobile) {
-      openModal({
-        type: "REPORT",
-        data: { refType: "POST_COMMENT", refId: id },
-        isFill: true,
-      });
-    } else {
-      openModal({
-        type: "REPORT",
-        data: { refType: "POST_COMMENT", refId: id },
-      });
-    }
+    openReportModal({ refType: "POST_COMMENT", refId: id });
   };
 
   const handleCommentDelete = async (id: string) => {

--- a/src/components/Board/Detail/Detail.tsx
+++ b/src/components/Board/Detail/Detail.tsx
@@ -21,6 +21,7 @@ import { ActionBarConfig } from "@/components/ActionBar/ActionBar.types";
 import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
 import { useProfileCardHover } from "@/hooks/useProfileCardHover";
+import { useReportModal } from "@/hooks/useReportModal";
 
 import { useModalStore } from "@/states/modalStore";
 import { useAuthStore } from "@/states/authStore";
@@ -46,6 +47,7 @@ export default function PostDetail({ id }: PostDetailProps) {
 
   const { isLoggedIn, user_id } = useAuthStore();
   const { openModal } = useModalStore();
+  const openReportModal = useReportModal();
 
   const { showToast } = useToast();
   const { isMobile } = useDeviceStore();
@@ -81,11 +83,9 @@ export default function PostDetail({ id }: PostDetailProps) {
   }, [posts, openModal, id]);
 
   const handleOpenReportModal = useCallback(() => {
-    openModal({
-      type: "REPORT",
-      data: { refType: "POST", refId: posts?.author.id },
-    });
-  }, [openModal, posts?.author.id]);
+    if (!posts?.author.id) return;
+    openReportModal({ refType: "POST", refId: posts.author.id });
+  }, [openReportModal, posts?.author.id]);
 
   const handleLikeClick = useCallback(() => {
     if (!isLoggedIn) {

--- a/src/components/ChatRoom/Header/Header.tsx
+++ b/src/components/ChatRoom/Header/Header.tsx
@@ -7,10 +7,10 @@ import IconComponent from "@/components/Asset/Icon";
 import ChatLeave from "@/components/Modal/ChatLeave/ChatLeave";
 import SideMenu from "@/components/Layout/SideMenu/SideMenu";
 
-import { useModalStore } from "@/states/modalStore";
 import { useDeviceStore } from "@/states/deviceStore";
 
 import { useModal } from "@/hooks/useModal";
+import { useReportModal } from "@/hooks/useReportModal";
 import useGoBack from "@/hooks/useGoBack";
 
 import type { UserBaseResponse } from "@grimity/dto";
@@ -25,7 +25,7 @@ interface ChatRoomHeaderProps {
 const ChatRoomHeader = ({ chatId, data }: ChatRoomHeaderProps) => {
   const router = useRouter();
   const { openModal } = useModal();
-  const { openModal: openModalStore } = useModalStore();
+  const openReportModal = useReportModal();
   const { isMobile } = useDeviceStore();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -45,11 +45,8 @@ const ChatRoomHeader = ({ chatId, data }: ChatRoomHeaderProps) => {
   };
 
   const handleOpenReportModal = () => {
-    openModalStore({
-      type: "REPORT",
-      data: { refType: "CHAT", refId: data?.id },
-      isFill: isMobile,
-    });
+    if (!data?.id) return;
+    openReportModal({ refType: "CHAT", refId: data.id });
     setIsDropdownOpen(false);
   };
 

--- a/src/components/Detail/Comment/Comment.tsx
+++ b/src/components/Detail/Comment/Comment.tsx
@@ -15,6 +15,7 @@ import { deleteCommentLike, putCommentLike } from "@/api/feeds-comments/putDelet
 
 import { useAuthStore } from "@/states/authStore";
 import { useModalStore } from "@/states/modalStore";
+import { useReportModal } from "@/hooks/useReportModal";
 
 import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
@@ -39,6 +40,7 @@ export default function Comment({ feedId, feedWriterId, isFollowingPage }: Comme
   const { data: userData, isLoading } = useMyData();
   const { showToast } = useToast();
   const openModal = useModalStore((state) => state.openModal);
+  const openReportModal = useReportModal();
   const queryClient = useQueryClient();
   const [replyText, setReplyText] = useState("");
   const [mentionedUser, setMentionedUser] = useState<CommentWriter | null>(null);
@@ -154,18 +156,7 @@ export default function Comment({ feedId, feedWriterId, isFollowingPage }: Comme
       return;
     }
 
-    if (isMobile) {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED_COMMENT", refId: id },
-        isFill: true,
-      });
-    } else {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED_COMMENT", refId: id },
-      });
-    }
+    openReportModal({ refType: "FEED_COMMENT", refId: id });
   };
 
   const handleCommentDelete = async (id: string) => {

--- a/src/components/Detail/Detail.tsx
+++ b/src/components/Detail/Detail.tsx
@@ -25,10 +25,10 @@ import ShareBtn from "./ShareBtn/ShareBtn";
 import { timeAgo } from "@/utils/timeAgo";
 import Chip from "../Chip/Chip";
 import { useModalStore } from "@/states/modalStore";
+import { useReportModal } from "@/hooks/useReportModal";
 import { deleteSave, putSave } from "@/api/feeds/putDeleteFeedsIdSave";
 import Comment from "./Comment/Comment";
 import NewFeed from "../Layout/NewFeed/NewFeed";
-import { useDeviceStore } from "@/states/deviceStore";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import { useAuthRefresh } from "@/hooks/useAuthRefresh";
 import ResponsiveImage from "@/components/ResponsiveImage/ResponsiveImage";
@@ -53,7 +53,7 @@ export default function Detail({ id }: DetailProps) {
   const sectionRef = usePreventRightClick<HTMLElement>();
   const router = useRouter();
   const openModal = useModalStore((state) => state.openModal);
-  const { isMobile } = useDeviceStore();
+  const openReportModal = useReportModal();
   usePreventScroll(!!overlayImage);
   const { triggerProps, popoverProps, isOpen, targetRef } = useProfileCardHover(
     details?.author.url,
@@ -138,18 +138,8 @@ export default function Detail({ id }: DetailProps) {
   };
 
   const handleOpenReportModal = () => {
-    if (isMobile) {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED", refId: details?.author.id },
-        isFill: true,
-      });
-    } else {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED", refId: details?.author.id },
-      });
-    }
+    if (!details?.author.id) return;
+    openReportModal({ refType: "FEED", refId: details.author.id });
   };
 
   const actionBarConfig: ActionBarConfig = useMemo(

--- a/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
+++ b/src/components/FollowingPage/FollowingFeed/FollowingFeed.tsx
@@ -14,6 +14,7 @@ import { timeAgo } from "@/utils/timeAgo";
 
 const Zoom = dynamic(() => import("react-medium-image-zoom"), { ssr: false });
 import { useModalStore } from "@/states/modalStore";
+import { useReportModal } from "@/hooks/useReportModal";
 import { deleteSave, putSave } from "@/api/feeds/putDeleteFeedsIdSave";
 import IconComponent from "@/components/Asset/Icon";
 import Dropdown from "@/components/Dropdown/Dropdown";
@@ -24,7 +25,6 @@ import CommentInput from "@/components/Detail/Comment/CommentInput/CommentInput"
 import Comment from "@/components/Detail/Comment/Comment";
 import { useGetFeedsComments } from "@/api/feeds-comments/getFeedComments";
 import { useMyData } from "@/api/users/getMe";
-import { useDeviceStore } from "@/states/deviceStore";
 import { FollowingFeedsResponse } from "@/api/feeds/getFeedsFollowing";
 import { usePreventRightClick } from "@/hooks/usePreventRightClick";
 import { useProfileCardHover } from "@/hooks/useProfileCardHover";
@@ -52,12 +52,12 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
   const [overlayImage, setOverlayImage] = useState<string | null>(null);
   const router = useRouter();
   const openModal = useModalStore((state) => state.openModal);
+  const openReportModal = useReportModal();
   const { refetch: refetchComments } = useGetFeedsComments({
     feedId: id,
   });
   const [isContentTooLong, setIsContentTooLong] = useState(false);
   const contentRef = useRef<HTMLParagraphElement | null>(null);
-  const { isMobile } = useDeviceStore();
   const imgRef = usePreventRightClick<HTMLImageElement>();
   const divRef = usePreventRightClick<HTMLDivElement>();
   const sectionRef = usePreventRightClick<HTMLElement>();
@@ -195,18 +195,8 @@ export default function FollowingFeed({ id, commentCount, details }: FollowingFe
   };
 
   const handleOpenReportModal = () => {
-    if (isMobile) {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED", refId: details?.author.id },
-        isFill: true,
-      });
-    } else {
-      openModal({
-        type: "REPORT",
-        data: { refType: "FEED", refId: details?.author.id },
-      });
-    }
+    if (!details?.author.id) return;
+    openReportModal({ refType: "FEED", refId: details.author.id });
   };
 
   return (

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,7 +5,6 @@ import { useModalStore } from "@/states/modalStore";
 import { usePreventScroll } from "@/hooks/usePreventScroll";
 import IconComponent from "../Asset/Icon";
 import Button from "../Button/Button";
-import Login from "./Login/Login";
 import Nickname from "./Nickname/Nickname";
 import ProfileId from "./ProfileId/ProfileId";
 import Join from "./Join/Join";
@@ -16,7 +15,6 @@ import Share from "./Share/Share";
 import UploadModal from "./Upload/Upload";
 import SharePost from "./SharePost/SharePost";
 import Like from "./Like/Like";
-import Report from "./Report/Report";
 import AlbumEdit from "./AlbumEdit/AlbumEdit";
 import AlbumSelect from "./AlbumSelect/AlbumSelect";
 import AlbumMove from "./AlbumMove/AlbumMove";
@@ -123,8 +121,6 @@ export default function Modal() {
         return <UploadModal {...data} />;
       case "LIKE":
         return <Like />;
-      case "REPORT":
-        return <Report {...data} closeModal={handleCloseModal} />;
       case "ALBUM-EDIT":
         return <AlbumEdit {...data} />;
       case "ALBUM-SELECT":

--- a/src/components/Modal/Provider/index.tsx
+++ b/src/components/Modal/Provider/index.tsx
@@ -61,7 +61,7 @@ function ModalProvider({ children }: PropsWithChildren) {
     <>
       {children}
       <ModalPortal>
-        {modals.map(({ id, content, props, isFill, title }) => {
+        {modals.map(({ id, content, props, isFill, title, bare }) => {
           const handleClose = () => {
             if (
               isFill &&
@@ -76,6 +76,12 @@ function ModalProvider({ children }: PropsWithChildren) {
           };
 
           const node = typeof content === "function" ? content(handleClose) : content;
+
+          // bare 모달은 자체 오버레이/포지셔닝을 갖는 디자인 시스템 컴포넌트를 위해
+          // provider 오버레이 래퍼 없이 그대로 렌더
+          if (bare) {
+            return <React.Fragment key={id}>{node}</React.Fragment>;
+          }
 
           if (isFill) {
             return (

--- a/src/components/Modal/Report/Report.module.scss
+++ b/src/components/Modal/Report/Report.module.scss
@@ -1,109 +1,90 @@
-@use "@/styles/globals.scss" as *;
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/typography/semantic" as typo;
+@use "@/styles/tokens/spacing" as spacing;
 
-.container {
-  width: 100%;
-  min-height: 500px;
+.alertOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: spacing.$spacing-24;
+  background-color: colors.$bg-overlay-black;
+}
+
+.form {
   display: flex;
   flex-direction: column;
+  gap: spacing.$spacing-20;
+}
 
-  .title {
-    @include Title3;
-    color: $gray70;
-  }
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$spacing-8;
+}
 
-  .message {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    @include Sub4;
-    color: $gray70;
-    margin-bottom: 16px;
+.fieldTitle {
+  margin: 0;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+  gap: spacing.$spacing-2;
+  @include typo.subtitle-2;
+  color: colors.$text-gray-bold;
+}
 
-    .op1 {
-      @include Body1;
-      color: $secandary1;
-    }
+.required {
+  @include typo.subtitle-2;
+  color: colors.$text-primary-normal;
+}
 
-    .op2 {
-      @include Body1;
-      color: $gray50;
-    }
-  }
+.optional {
+  @include typo.subtitle-2;
+  color: colors.$text-gray-subtle;
+}
 
-  .typeContainer {
-    margin-top: 24px;
-    margin-bottom: 30px;
-    display: flex;
-    flex-direction: column;
+.reasonList {
+  display: flex;
+  flex-direction: column;
+}
 
-    .options {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
+.detailTextarea {
+  min-height: 155px;
+}
 
-      .radioLabel {
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-        position: relative;
-        @include Sub4;
-        color: $gray80;
-      }
+/* ===== 모바일 레이아웃 ===== */
+.mobileFill {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background-color: colors.$surface-base;
+}
 
-      .radioInput {
-        display: none;
-      }
+.mobileContent {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$spacing-20;
+  padding: spacing.$spacing-16;
+  padding-top: calc(52px + #{spacing.$spacing-16});
+}
 
-      .radioImage {
-        width: 20px;
-        height: 20px;
-        background-image: url("/icon/radio-off.svg");
-        background-size: cover;
-        margin-right: 12px;
-      }
+.mobileActions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: spacing.$spacing-8;
+  padding: spacing.$spacing-8 spacing.$spacing-16 spacing.$spacing-16;
+}
 
-      .radioInput:checked + .radioImage {
-        background-image: url("/icon/radio-on.svg");
-      }
-    }
-  }
-
-  .textareaContainer {
-    width: 100%;
-    min-height: 100px;
-    border-radius: 12px;
-    border: 1px solid $gray30;
-    background: $gray10;
-    padding: 12px 16px;
-
-    &:focus-within {
-      background-color: $gray0;
-    }
-
-    .textarea {
-      width: 100%;
-      min-height: 95px;
-      background: none;
-      resize: none;
-      border: none;
-      outline: none;
-      @include Body1;
-      color: $gray80;
-
-      &::placeholder {
-        color: $gray50;
-      }
-
-      &:focus-within {
-        background-color: $gray0;
-      }
-    }
-  }
-
-  .btns {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    margin-top: 30px;
-  }
+.mobileActionButton {
+  flex: 1;
+  min-width: 0;
+  display: flex;
 }

--- a/src/components/Modal/Report/Report.module.scss
+++ b/src/components/Modal/Report/Report.module.scss
@@ -2,17 +2,6 @@
 @use "@/styles/tokens/typography/semantic" as typo;
 @use "@/styles/tokens/spacing" as spacing;
 
-.alertOverlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: spacing.$spacing-24;
-  background-color: colors.$bg-overlay-black;
-}
-
 .form {
   display: flex;
   flex-direction: column;

--- a/src/components/Modal/Report/Report.tsx
+++ b/src/components/Modal/Report/Report.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useToast } from "@/hooks/useToast";
 import { useDeviceStore } from "@/states/deviceStore";
 import Modal from "@/components/common/PopUp/Modal/Modal";
+import Backdrop from "@/components/common/PopUp/Backdrop/Backdrop";
 import Alert from "@/components/common/PopUp/Alert/Alert";
 import GNB from "@/components/common/Navigation/GNB/GNB";
 import ListItem from "@/components/common/Cell/ListItem/ListItem";
@@ -28,6 +29,7 @@ const MAX_DETAIL_LENGTH = 500;
 export default function Report({ refType, refId, onClose }: ReportProps) {
   const { showToast } = useToast();
   const { isMobile } = useDeviceStore();
+  const alertSize = isMobile ? "md" : "xl";
 
   const [step, setStep] = useState<ReportStep>("form");
   const [reason, setReason] = useState<ReportType | null>(null);
@@ -64,10 +66,10 @@ export default function Report({ refType, refId, onClose }: ReportProps) {
 
   if (step === "confirm") {
     return (
-      <div className={styles.alertOverlay}>
+      <Backdrop>
         <Alert
           variant="content"
-          size={isMobile ? "md" : "xl"}
+          size={alertSize}
           title="신고하시겠어요?"
           contentText={"신고 접수 후에는 취소가 어려워요.\n허위 신고 시 서비스 이용이 제한될 수 있어요."}
           secondaryLabel="아니요"
@@ -75,22 +77,22 @@ export default function Report({ refType, refId, onClose }: ReportProps) {
           primaryLabel="신고하기"
           onPrimary={handleConfirmSubmit}
         />
-      </div>
+      </Backdrop>
     );
   }
 
   if (step === "complete") {
     return (
-      <div className={styles.alertOverlay}>
+      <Backdrop>
         <Alert
           variant="normal"
-          size={isMobile ? "md" : "xl"}
+          size={alertSize}
           title="신고가 접수되었어요"
           contentText={"관리자의 검토 후\n적절한 조치가 이루어질 예정이에요"}
           primaryLabel="확인"
           onPrimary={onClose}
         />
-      </div>
+      </Backdrop>
     );
   }
 
@@ -135,11 +137,19 @@ export default function Report({ refType, refId, onClose }: ReportProps) {
 
   if (isMobile) {
     return (
-      <div className={styles.mobileFill}>
+      <div
+        className={styles.mobileFill}
+        role="dialog"
+        aria-modal="true"
+        aria-label="신고하기"
+      >
         <GNB variant="three-button" title="신고하기" onBack={onClose} />
 
         <div className={styles.mobileContent}>{formFields}</div>
 
+        {/*
+         * TODO: 공통 Modal에 fullscreen/mobile variant가 추가되면 이 푸터를 그쪽으로 통합한다.
+         */}
         <div className={styles.mobileActions}>
           <OutlinedButton
             size="large"

--- a/src/components/Modal/Report/Report.tsx
+++ b/src/components/Modal/Report/Report.tsx
@@ -1,97 +1,173 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useToast } from "@/hooks/useToast";
-import styles from "./Report.module.scss";
-import { useModalStore } from "@/states/modalStore";
-import Button from "@/components/Button/Button";
-import { ReportProps } from "./Report.types";
+import { useDeviceStore } from "@/states/deviceStore";
+import Modal from "@/components/common/PopUp/Modal/Modal";
+import Alert from "@/components/common/PopUp/Alert/Alert";
+import GNB from "@/components/common/Navigation/GNB/GNB";
+import ListItem from "@/components/common/Cell/ListItem/ListItem";
+import TextArea from "@/components/common/Input/TextArea/TextArea";
+import SolidButton from "@/components/common/Button/SolidButton/SolidButton";
+import OutlinedButton from "@/components/common/Button/OutlinedButton/OutlinedButton";
 import { postReports, ReportType } from "@/api/reports/postReports";
+import { ReportProps } from "./Report.types";
+import styles from "./Report.module.scss";
 
-export default function Report({ refType, refId, closeModal }: ReportProps) {
+type ReportStep = "form" | "confirm" | "complete";
+
+const REPORT_REASONS: ReportType[] = [
+  "사칭계정",
+  "스팸/도배",
+  "욕설/비방",
+  "부적절한 프로필",
+  "선정적인 컨텐츠",
+  "기타",
+];
+
+const MAX_DETAIL_LENGTH = 500;
+
+export default function Report({ refType, refId, onClose }: ReportProps) {
   const { showToast } = useToast();
-  const openModal = useModalStore((state) => state.openModal);
+  const { isMobile } = useDeviceStore();
 
-  const [reason, setReason] = useState<ReportType>("사칭계정");
+  const [step, setStep] = useState<ReportStep>("form");
+  const [reason, setReason] = useState<ReportType | null>(null);
   const [details, setDetails] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = () => {
-    if (!reason) {
-      showToast("신고 사유를 선택해주세요.", "error");
-      return;
-    }
+  const isDetailRequired = reason === "기타";
+  const canSubmit = reason !== null && (!isDetailRequired || details.trim().length > 0);
 
-    openModal({
-      type: null,
-      data: {
-        title: "신고하시겠어요?",
-        subtitle: "신고 접수 후에는 취소가 어려워요.",
-        confirmBtn: "신고하기",
-        onClick: async () => {
-          try {
-            const response = await postReports({
-              type: reason,
-              refType,
-              refId,
-              content: details || undefined,
-            });
-            if (response) {
-              showToast("신고가 접수되었어요.", "success");
-              closeModal();
-            }
-          } catch (err) {
-            showToast("신고 중 오류가 발생했습니다.", "error");
-            closeModal();
-          }
-        },
-      },
-      isComfirm: true,
-    });
+  const handleRequestSubmit = () => {
+    if (!canSubmit) return;
+    setStep("confirm");
   };
 
-  return (
-    <div className={styles.container}>
-      <div className={styles.title}>신고하기</div>
-      <div className={styles.typeContainer}>
-        <div className={styles.message}>
-          신고 사유를 선택해주세요 <p className={styles.op1}>(필수)</p>
-        </div>
-        <section className={styles.options}>
-          {["사칭계정", "스팸/도배", "욕설/비방", "부적절한 프로필", "선정적인 컨텐츠", "기타"].map(
-            (option) => (
-              <label key={option} className={styles.radioLabel}>
-                <input
-                  type="radio"
-                  name="reason"
-                  value={option}
-                  checked={reason === option}
-                  className={styles.radioInput}
-                  onChange={(e) => setReason(e.target.value as ReportType)}
-                />
-                <span className={styles.radioImage}></span>
-                {option}
-              </label>
-            ),
-          )}
-        </section>
-      </div>
-      <div className={styles.message}>
-        자세한 내용을 알려주세요 <p className={styles.op2}>(선택)</p>
-      </div>
-      <div className={styles.textareaContainer}>
-        <textarea
-          placeholder="구체적인 사유를 적어주세요."
-          value={details}
-          className={styles.textarea}
-          onChange={(e) => setDetails(e.target.value)}
+  const handleConfirmSubmit = async () => {
+    if (reason === null || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await postReports({
+        type: reason,
+        refType,
+        refId,
+        content: details.trim() || undefined,
+      });
+      setStep("complete");
+    } catch {
+      showToast("신고 중 오류가 발생했습니다.", "error");
+      setStep("form");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (step === "confirm") {
+    return (
+      <div className={styles.alertOverlay}>
+        <Alert
+          variant="content"
+          size={isMobile ? "md" : "xl"}
+          title="신고하시겠어요?"
+          contentText={"신고 접수 후에는 취소가 어려워요.\n허위 신고 시 서비스 이용이 제한될 수 있어요."}
+          secondaryLabel="아니요"
+          onSecondary={() => setStep("form")}
+          primaryLabel="신고하기"
+          onPrimary={handleConfirmSubmit}
         />
       </div>
-      <div className={styles.btns}>
-        <Button size="l" type="outlined-assistive" onClick={closeModal}>
-          취소
-        </Button>
-        <Button size="l" type="filled-primary" onClick={handleSubmit}>
-          신고하기
-        </Button>
+    );
+  }
+
+  if (step === "complete") {
+    return (
+      <div className={styles.alertOverlay}>
+        <Alert
+          variant="normal"
+          size={isMobile ? "md" : "xl"}
+          title="신고가 접수되었어요"
+          contentText={"관리자의 검토 후\n적절한 조치가 이루어질 예정이에요"}
+          primaryLabel="확인"
+          onPrimary={onClose}
+        />
       </div>
-    </div>
+    );
+  }
+
+  const formFields = (
+    <>
+      <section className={styles.field}>
+        <h3 className={styles.fieldTitle}>
+          신고 사유를 선택해주세요 <span className={styles.required}>(필수)</span>
+        </h3>
+        <div className={styles.reasonList}>
+          {REPORT_REASONS.map((option) => (
+            <ListItem
+              key={option}
+              type="radio"
+              text={option}
+              active={reason === option}
+              onClick={() => setReason(option)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.field}>
+        <h3 className={styles.fieldTitle}>
+          자세한 내용을 알려주세요{" "}
+          {isDetailRequired ? (
+            <span className={styles.required}>(필수)</span>
+          ) : (
+            <span className={styles.optional}>(선택)</span>
+          )}
+        </h3>
+        <TextArea
+          className={styles.detailTextarea}
+          maxCount={MAX_DETAIL_LENGTH}
+          placeholder="구체적인 사유를 적어주세요"
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+        />
+      </section>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <div className={styles.mobileFill}>
+        <GNB variant="three-button" title="신고하기" onBack={onClose} />
+
+        <div className={styles.mobileContent}>{formFields}</div>
+
+        <div className={styles.mobileActions}>
+          <span className={styles.mobileActionButton}>
+            <OutlinedButton size="large" onClick={onClose}>
+              닫기
+            </OutlinedButton>
+          </span>
+          <span className={styles.mobileActionButton}>
+            <SolidButton size="large" onClick={handleRequestSubmit} disabled={!canSubmit}>
+              신고하기
+            </SolidButton>
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Modal
+      title="신고하기"
+      onClose={onClose}
+      buttonType="double"
+      secondaryLabel="닫기"
+      onSecondary={onClose}
+      primaryLabel="신고하기"
+      onPrimary={handleRequestSubmit}
+      primaryDisabled={!canSubmit}
+    >
+      <div className={styles.form}>{formFields}</div>
+    </Modal>
   );
 }

--- a/src/components/Modal/Report/Report.tsx
+++ b/src/components/Modal/Report/Report.tsx
@@ -141,16 +141,21 @@ export default function Report({ refType, refId, onClose }: ReportProps) {
         <div className={styles.mobileContent}>{formFields}</div>
 
         <div className={styles.mobileActions}>
-          <span className={styles.mobileActionButton}>
-            <OutlinedButton size="large" onClick={onClose}>
-              닫기
-            </OutlinedButton>
-          </span>
-          <span className={styles.mobileActionButton}>
-            <SolidButton size="large" onClick={handleRequestSubmit} disabled={!canSubmit}>
-              신고하기
-            </SolidButton>
-          </span>
+          <OutlinedButton
+            size="large"
+            onClick={onClose}
+            className={styles.mobileActionButton}
+          >
+            닫기
+          </OutlinedButton>
+          <SolidButton
+            size="large"
+            onClick={handleRequestSubmit}
+            disabled={!canSubmit}
+            className={styles.mobileActionButton}
+          >
+            신고하기
+          </SolidButton>
         </div>
       </div>
     );

--- a/src/components/Modal/Report/Report.types.ts
+++ b/src/components/Modal/Report/Report.types.ts
@@ -3,5 +3,5 @@ import { ReportRefType } from "@/api/reports/postReports";
 export interface ReportProps {
   refType: ReportRefType;
   refId: string;
-  closeModal: () => void;
+  onClose: () => void;
 }

--- a/src/components/ProfilePage/Profile/Profile.tsx
+++ b/src/components/ProfilePage/Profile/Profile.tsx
@@ -3,6 +3,7 @@ import router, { useRouter } from "next/router";
 
 import { useAuthStore } from "@/states/authStore";
 import { useModalStore } from "@/states/modalStore";
+import { useReportModal } from "@/hooks/useReportModal";
 
 import { useMyData } from "@/api/users/getMe";
 import { useUserDataByUrl } from "@/api/users/getId";
@@ -35,6 +36,7 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
   const setIsLoggedIn = useAuthStore((state) => state.setIsLoggedIn);
   const setUserId = useAuthStore((state) => state.setUserId);
   const openModal = useModalStore((state) => state.openModal);
+  const openReportModal = useReportModal();
 
   const { data: myData } = useMyData();
   const { data: userData, refetch: refetchUserData } = useUserDataByUrl(url);
@@ -101,7 +103,8 @@ export default function Profile({ isMyProfile, id, url }: ProfileProps) {
       showToast("로그인 후 가능합니다.", "warning");
       return;
     }
-    openModal({ type: "REPORT", data: { refType: "USER", refId: userData?.id }, isFill: isMobile });
+    if (!userData?.id) return;
+    openReportModal({ refType: "USER", refId: userData.id });
   };
 
   const handleWithdrawal = async () => {

--- a/src/components/common/PopUp/Alert/Alert.module.scss
+++ b/src/components/common/PopUp/Alert/Alert.module.scss
@@ -50,7 +50,7 @@
   color: colors.$text-gray-bold;
   word-break: break-word;
   overflow-wrap: break-word;
-  white-space: normal;
+  white-space: pre-line;
   @include typo.body-2-r;
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/src/components/common/PopUp/Backdrop/Backdrop.module.scss
+++ b/src/components/common/PopUp/Backdrop/Backdrop.module.scss
@@ -1,0 +1,13 @@
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/spacing" as spacing;
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: spacing.$spacing-24;
+  background-color: colors.$bg-overlay-black;
+}

--- a/src/components/common/PopUp/Backdrop/Backdrop.tsx
+++ b/src/components/common/PopUp/Backdrop/Backdrop.tsx
@@ -1,0 +1,16 @@
+import clsx from "clsx";
+import styles from "./Backdrop.module.scss";
+import type { BackdropProps } from "./Backdrop.types";
+
+/**
+ * 화면 중앙 정렬 모달용 공용 backdrop(딤 오버레이) primitive.
+ * 자체 backdrop을 갖지 않는 DS 컴포넌트(PopUp/Modal, PopUp/Alert 등)를
+ * 화면 중앙에 띄울 때 공통으로 사용한다. role/aria/onClick 등은 ...rest로 전달한다.
+ */
+export default function Backdrop({ children, className, ...rest }: BackdropProps) {
+  return (
+    <div className={clsx(styles.backdrop, className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/PopUp/Backdrop/Backdrop.types.ts
+++ b/src/components/common/PopUp/Backdrop/Backdrop.types.ts
@@ -1,0 +1,5 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export interface BackdropProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}

--- a/src/components/common/PopUp/Modal/Modal.module.scss
+++ b/src/components/common/PopUp/Modal/Modal.module.scss
@@ -3,17 +3,6 @@
 @use "@/styles/tokens/spacing" as spacing;
 @use "@/styles/tokens/typography/semantic" as typo;
 
-.overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: spacing.$spacing-24;
-  background-color: colors.$bg-overlay-black;
-}
-
 .modal {
   box-sizing: border-box;
   display: flex;

--- a/src/components/common/PopUp/Modal/Modal.tsx
+++ b/src/components/common/PopUp/Modal/Modal.tsx
@@ -55,12 +55,20 @@ export default function Modal(props: ModalProps) {
             {props.buttonType === "double" && (
               <>
                 <div className={styles.buttonWrap}>
-                  <OutlinedButton size="large" onClick={props.onSecondary}>
+                  <OutlinedButton
+                    size="large"
+                    onClick={props.onSecondary}
+                    disabled={props.secondaryDisabled}
+                  >
                     {props.secondaryLabel}
                   </OutlinedButton>
                 </div>
                 <div className={styles.buttonWrap}>
-                  <SolidButton size="large" onClick={props.onPrimary}>
+                  <SolidButton
+                    size="large"
+                    onClick={props.onPrimary}
+                    disabled={props.primaryDisabled}
+                  >
                     {props.primaryLabel}
                   </SolidButton>
                 </div>
@@ -68,14 +76,22 @@ export default function Modal(props: ModalProps) {
             )}
             {props.buttonType === "primary" && (
               <div className={styles.buttonWrap}>
-                <SolidButton size="large" onClick={props.onPrimary}>
+                <SolidButton
+                  size="large"
+                  onClick={props.onPrimary}
+                  disabled={props.primaryDisabled}
+                >
                   {props.primaryLabel}
                 </SolidButton>
               </div>
             )}
             {props.buttonType === "secondary" && (
               <div className={styles.buttonWrap}>
-                <OutlinedButton size="large" onClick={props.onSecondary}>
+                <OutlinedButton
+                  size="large"
+                  onClick={props.onSecondary}
+                  disabled={props.secondaryDisabled}
+                >
                   {props.secondaryLabel}
                 </OutlinedButton>
               </div>

--- a/src/components/common/PopUp/Modal/Modal.tsx
+++ b/src/components/common/PopUp/Modal/Modal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import clsx from "clsx";
 import SolidButton from "@/components/common/Button/SolidButton/SolidButton";
 import OutlinedButton from "@/components/common/Button/OutlinedButton/OutlinedButton";
+import Backdrop from "@/components/common/PopUp/Backdrop/Backdrop";
 import styles from "./Modal.module.scss";
 import type { ModalProps } from "./Modal.types";
 import Icon from "@/components/common/Icon/Icon";
@@ -15,8 +15,8 @@ export default function Modal(props: ModalProps) {
     props.buttonType === "double";
 
   return (
-    <div
-      className={clsx(styles.overlay, className)}
+    <Backdrop
+      className={className}
       role="dialog"
       aria-modal="true"
       aria-labelledby="modal-title"
@@ -99,6 +99,6 @@ export default function Modal(props: ModalProps) {
           </footer>
         )}
       </div>
-    </div>
+    </Backdrop>
   );
 }

--- a/src/components/common/PopUp/Modal/Modal.types.ts
+++ b/src/components/common/PopUp/Modal/Modal.types.ts
@@ -5,19 +5,23 @@ type ButtonConfig =
       buttonType: "primary";
       primaryLabel: string;
       onPrimary: () => void;
+      primaryDisabled?: boolean;
     }
   | {
       buttonType: "secondary";
       secondaryLabel: string;
       onSecondary: () => void;
+      secondaryDisabled?: boolean;
     }
   | { buttonType: "tertiary" }
   | {
       buttonType: "double";
       primaryLabel: string;
       onPrimary: () => void;
+      primaryDisabled?: boolean;
       secondaryLabel: string;
       onSecondary: () => void;
+      secondaryDisabled?: boolean;
     }
   | { buttonType?: never };
 

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -11,10 +11,11 @@ export function useModal() {
     options?: {
       isFill?: boolean;
       title?: string;
+      bare?: boolean;
     },
   ) {
     const id = uuidv4();
-    open(id, content, props, options?.isFill, options?.title);
+    open(id, content, props, options?.isFill, options?.title, options?.bare);
     return () => close(id);
   }
 

--- a/src/hooks/useReportModal.tsx
+++ b/src/hooks/useReportModal.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { useNewModalStore } from "@/states/modalStore";
+import { useDeviceStore } from "@/states/deviceStore";
+import Report from "@/components/Modal/Report/Report";
+import { ReportRefType } from "@/api/reports/postReports";
+
+export interface OpenReportParams {
+  refType: ReportRefType;
+  refId: string;
+}
+
+/**
+ * 신고하기 모달
+ * Report 컴포넌트가 자체 오버레이/레이아웃을 가지므로 bare 옵션으로 마운트
+ */
+export function useReportModal() {
+  const open = useNewModalStore((s) => s.openModal);
+  const close = useNewModalStore((s) => s.closeModal);
+  const isMobile = useDeviceStore((s) => s.isMobile);
+
+  return useCallback(
+    ({ refType, refId }: OpenReportParams) => {
+      const id = uuidv4();
+      open(
+        id,
+        (handleClose) => <Report refType={refType} refId={refId} onClose={handleClose} />,
+        undefined,
+        isMobile,
+        undefined,
+        true,
+      );
+      return () => close(id);
+    },
+    [open, close, isMobile],
+  );
+}

--- a/src/states/modalStore.ts
+++ b/src/states/modalStore.ts
@@ -15,7 +15,6 @@ export type ModalType =
   | "SHAREPOST"
   | "UPLOAD"
   | "LIKE"
-  | "REPORT"
   | "ALBUM-EDIT"
   | "ALBUM-SELECT"
   | "ALBUM-MOVE"
@@ -69,17 +68,25 @@ type NewModalType<T = Record<string, unknown>> = {
   props?: T;
   isFill?: boolean;
   title?: string;
+  bare?: boolean;
 };
 
 interface NewModalState<T = Record<string, unknown>> {
   modals: NewModalType<T>[];
-  openModal: (id: string, content: ModalContent, props?: T, isFill?: boolean, title?: string) => void;
+  openModal: (
+    id: string,
+    content: ModalContent,
+    props?: T,
+    isFill?: boolean,
+    title?: string,
+    bare?: boolean,
+  ) => void;
   closeModal: (id: string) => void;
 }
 
 export const useNewModalStore = create<NewModalState>((set) => ({
   modals: [],
-  openModal: (id, content, props, isFill, title) =>
-    set((state) => ({ modals: [...state.modals, { id, content, props, isFill, title }] })),
+  openModal: (id, content, props, isFill, title, bare) =>
+    set((state) => ({ modals: [...state.modals, { id, content, props, isFill, title, bare }] })),
   closeModal: (id) => set((state) => ({ modals: state.modals.filter((m) => m.id !== id) })),
 }));


### PR DESCRIPTION
### 🔎 작업 내용
- [x] 신고하기(Report) 모달을 디자인 시스템 컴포넌트로 재작성 (PopUp/Modal·Alert·ListItem·TextArea)
- [x] 신고 플로우 구현: 폼 → 확인 → 완료 (기존 toast → 완료 Alert로 변경)
- [x] "기타" 사유 선택 시 상세 입력 필수 전환, 사유 미선택 시 제출 버튼 비활성
- [x] 반응형 분기: 데스크톱은 PopUp/Modal, 모바일은 전체화면 + GNB(three-button) 헤더
- [x] 신규 모달 시스템(useModal/useNewModalStore)으로 이전 및 호출부 7곳 마이그레이션 (Feed/Board Detail·Comment, FollowingFeed, ChatRoom, Profile)
- [x] useReportModal 훅 추가, 레거시 REPORT 모달 플로우 제거

### 📸 스크린샷
### 데스크톱
<img width="2048" height="1216" alt="image" src="https://github.com/user-attachments/assets/0f47ada0-cf47-4db1-a227-b4e9ad978d9b" />
<img width="517" height="366" alt="image" src="https://github.com/user-attachments/assets/1b1f4080-ddd4-4e72-944b-c41333d35226" />
<img width="533" height="358" alt="image" src="https://github.com/user-attachments/assets/2bfb48b9-5596-4596-a8af-8f9c23b4901f" />

### 태블릿
<img width="890" height="1184" alt="image" src="https://github.com/user-attachments/assets/99f8ad1f-ba02-466a-954c-4d4b3d922ccb" />

### 모바일
<img width="406" height="855" alt="image" src="https://github.com/user-attachments/assets/18e3e13e-f9bf-4d53-bbf6-7be9ddc7de28" />


### 📢 전달사항

- 디자인 시스템 공통 컴포넌트 보강
  - 모달 인프라에 `bare` 옵션 추가 — 자체 오버레이를 갖는 DS 컴포넌트(PopUp/Modal·BottomSheet 등) 마운트 시 provider 오버레이 래퍼 생략. 이후 다른 DS 모달 이전에도 재사용 가능
  - `PopUp/Modal` 푸터 버튼에 `primaryDisabled`/`secondaryDisabled` 지원 추가 (시안의 비활성 "신고하기" 버튼용)
  - `PopUp/Alert` 본문 `white-space: pre-line` 적용 — 시안대로 `\n` 줄바꿈 표시 (기존 Alert는 `\n`이 없어 동작 동일)
- 모바일은 `GNB`가 `position: fixed`라 콘텐츠 상단에 GNB 높이(52px)만큼 패딩 보정
