### PR TITLE
[Fix] 모바일 홈 그림 올리기 FAB 추가 및 자유게시판/공지사항 레이아웃 수정

### DIFF
--- a/src/components/Layout/MainBoard/MainBoard.module.scss
+++ b/src/components/Layout/MainBoard/MainBoard.module.scss
@@ -4,6 +4,7 @@
 
 .container {
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 

--- a/src/components/common/Button/FloatingButton/FloatingButton.module.scss
+++ b/src/components/common/Button/FloatingButton/FloatingButton.module.scss
@@ -1,0 +1,27 @@
+@use "@/styles/tokens/colors/semantic" as colors;
+@use "@/styles/tokens/colors/atomic" as atomic;
+@use "@/styles/tokens/radius" as radius;
+
+.fab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 54px;
+  height: 54px;
+  padding: 0;
+  border: none;
+  border-radius: radius.$radius-full;
+  background-color: colors.$surface-primary-normal;
+  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, atomic.$opacity10);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:active {
+    background-color: colors.$surface-black;
+  }
+
+  &:disabled {
+    background-color: colors.$surface-gray-subtle;
+    cursor: not-allowed;
+  }
+}

--- a/src/components/common/Button/FloatingButton/FloatingButton.stories.tsx
+++ b/src/components/common/Button/FloatingButton/FloatingButton.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import FloatingButton from "./FloatingButton";
+
+const meta = {
+  title: "Common/Button/FloatingButton",
+  component: FloatingButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof FloatingButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    "aria-label": "그림 올리기",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    "aria-label": "그림 올리기",
+    disabled: true,
+  },
+};

--- a/src/components/common/Button/FloatingButton/FloatingButton.tsx
+++ b/src/components/common/Button/FloatingButton/FloatingButton.tsx
@@ -1,0 +1,31 @@
+import clsx from "clsx";
+import Icon from "@/components/common/Icon/Icon";
+import styles from "./FloatingButton.module.scss";
+import { FloatingButtonProps } from "./FloatingButton.types";
+
+/**
+ * 화면 위에 떠 있는 원형 액션 버튼(FAB). 기본은 plus 아이콘이며 모바일 그림 올리기
+ * 진입점 등에 사용한다. 고정 위치는 사용처에서 className으로 지정한다.
+ */
+export default function FloatingButton({
+  icon,
+  disabled = false,
+  onClick,
+  onMouseDown,
+  className,
+  type = "button",
+  "aria-label": ariaLabel,
+}: FloatingButtonProps) {
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+      aria-label={ariaLabel}
+      className={clsx(styles.fab, className)}
+    >
+      {icon ?? <Icon name="plus" size={24} color="white" />}
+    </button>
+  );
+}

--- a/src/components/common/Button/FloatingButton/FloatingButton.types.ts
+++ b/src/components/common/Button/FloatingButton/FloatingButton.types.ts
@@ -1,0 +1,5 @@
+import { ButtonBaseProps } from "@/components/common/Button/Button.types";
+
+export interface FloatingButtonProps extends ButtonBaseProps {
+  icon?: React.ReactNode;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import Banner from "@/components/Layout/Banner/Banner";
 import Ranking from "@/components/Layout/Ranking/Ranking";
 import MainBoard from "@/components/Layout/MainBoard/MainBoard";
 import NewFeed from "@/components/Layout/NewFeed/NewFeed";
+import FloatingButton from "@/components/common/Button/FloatingButton/FloatingButton";
 
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 
@@ -42,11 +43,18 @@ export default function Home() {
           <Ranking />
           <section className={styles.BoardSection}>
             <MainBoard type="ALL" />
-            {!isMobile && <MainBoard type="NOTICE" />}
+            <MainBoard type="NOTICE" />
           </section>
           <NewFeed />
         </section>
       </div>
+      {isMobile && (
+        <FloatingButton
+          className={styles.uploadFab}
+          aria-label="그림 올리기"
+          onClick={() => router.push("/write")}
+        />
+      )}
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 
 import { useDeviceStore } from "@/states/deviceStore";
+import { useAuthStore } from "@/states/authStore";
 
 import { InitialPageMeta } from "@/components/MetaData/MetaData";
 import Banner from "@/components/Layout/Banner/Banner";
@@ -22,6 +23,7 @@ export default function Home() {
   const [OGUrl, setOGUrl] = useState(serviceUrl);
   const { restoreScrollPosition } = useScrollRestoration("home-scroll");
   const { isMobile } = useDeviceStore();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   useEffect(() => {
     setOGUrl(`${serviceUrl}/${router.asPath}`);
@@ -48,7 +50,7 @@ export default function Home() {
           <NewFeed />
         </section>
       </div>
-      {isMobile && (
+      {isMobile && isLoggedIn && (
         <FloatingButton
           className={styles.uploadFab}
           aria-label="그림 올리기"

--- a/src/styles/pages/home.module.scss
+++ b/src/styles/pages/home.module.scss
@@ -44,3 +44,10 @@
     }
   }
 }
+
+.uploadFab {
+  position: fixed;
+  right: spacing.$spacing-16;
+  bottom: spacing.$spacing-16;
+  z-index: 100;
+}


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 그림 올리기 플로팅 버튼(FAB) 디자인 시스템 선언 (`common/Button/FloatingButton`)
- [x] 모바일 홈에 FAB 배치 (우하단 고정) → `/write` 연결 (모바일 업로드 진입점이 없어 보완)
- [x] 자유게시판 최신글 제목이 길 때 말줄임(…) 적용
- [x] 모바일 뷰 자유게시판 최신글 "더보기" 버튼 복귀 (overflow로 화면 밖에 밀려있던 문제)
- [x] 모바일 뷰 공지사항 노출

### 📸 스크린샷
<img width="311" height="665" alt="image" src="https://github.com/user-attachments/assets/7850cd69-2cc7-477e-b913-2adaf87802f5" /><img width="318" height="683" alt="image" src="https://github.com/user-attachments/assets/f55d1d04-7aa0-474d-a223-8ee24b24b9d9" />



### 📢 전달사항
