### PR TITLE
[Hotfix] 설정 화면 테마 메뉴 비노출 및 GNB 이슈 수정 

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -91,7 +91,7 @@ export default function Layout({ children }: LayoutProps) {
   const notificationRef = useRef<HTMLDivElement>(null);
   const profileRef = useRef<HTMLDivElement>(null);
 
-  usePreventScroll(isMobile && showNotifications);
+  usePreventScroll(isMobile && (showNotifications || isMobileSidebarOpen));
   useOnClickOutside(notificationRef, () => setShowNotifications(false));
   useOnClickOutside(profileRef, () => setIsProfileDropdownOpen(false));
 
@@ -100,7 +100,10 @@ export default function Layout({ children }: LayoutProps) {
     router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`);
   }, [router]);
 
-  const goToSearch = useCallback(() => router.push("/search"), [router]);
+  const goToSearch = useCallback(() => {
+    setIsMobileSidebarOpen(false);
+    router.push("/search");
+  }, [router]);
 
   const goToUpload = useCallback(() => {
     const isBoardPage = BOARD_WRITE_ROUTES.includes(router.pathname);
@@ -123,7 +126,8 @@ export default function Layout({ children }: LayoutProps) {
   const isSubRoute = isMobile && !MAIN_ROUTES.includes(router.pathname);
   const showUploadBtn = !UPLOAD_HIDDEN_ROUTES.includes(router.pathname);
   const showSubSearch = !SUB_SEARCH_HIDDEN_ROUTES.includes(router.pathname);
-  const shouldHideHeader = router.pathname === "/direct/[chatId]" && isMobile;
+  const shouldHideHeader =
+    (router.pathname === "/direct/[chatId]" && isMobile) || router.pathname === "/login";
   const isMobileSearchPage = isMobile && router.pathname === "/search";
 
   const {
@@ -355,7 +359,10 @@ export default function Layout({ children }: LayoutProps) {
             hasNotification={Boolean(myData?.hasNotification)}
             profileImageUrl={myData?.image ?? undefined}
             onSearch={goToSearch}
-            onBell={() => setShowNotifications((prev) => !prev)}
+            onBell={() => {
+              setIsMobileSidebarOpen(false);
+              setShowNotifications((prev) => !prev);
+            }}
             onProfile={onProfileClick}
             onUpload={showUploadBtn ? goToUpload : undefined}
             onLogin={goToLogin}

--- a/src/components/Settings/SettingsNav/SettingsNav.tsx
+++ b/src/components/Settings/SettingsNav/SettingsNav.tsx
@@ -18,7 +18,8 @@ interface SettingsNavItem {
 
 export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
   { key: "account", label: "내 계정", icon: "person", path: "/settings/account" },
-  { key: "theme", label: "화면 테마", icon: "palette", path: "/settings/theme" },
+  // 다크 토큰이 전 페이지에 적용될 때까지 화면 테마 메뉴 비노출
+  // { key: "theme", label: "화면 테마", icon: "palette", path: "/settings/theme" },
   { key: "notifications", label: "알림", icon: "bell", path: "/settings/notifications" },
   { key: "guide", label: "이용 안내", icon: "info-circle", path: "/settings/guide" },
   { key: "inquiry", label: "문의하기", icon: "question-circle", path: "/settings/inquiry" },

--- a/src/states/themeStore.ts
+++ b/src/states/themeStore.ts
@@ -5,6 +5,10 @@ export type ThemeMode = "system" | "light" | "dark";
 
 const THEME_KEY = "theme";
 
+// HOTFIX: 다크 토큰이 전 페이지에 적용될 때까지 다크모드를 잠근다.
+// 준비되면 true 로 바꾸면 저장된 사용자 설정/시스템 테마가 그대로 복원된다.
+const DARK_MODE_ENABLED = false;
+
 function getSystemTheme(): Theme {
   if (typeof window === "undefined") return "light";
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -48,6 +52,12 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   },
 
   initialize: () => {
+    if (!DARK_MODE_ENABLED) {
+      applyDataTheme("light");
+      set({ mode: "light", theme: "light" });
+      return () => {};
+    }
+
     let stored: string | null = null;
     try {
       stored = localStorage.getItem(THEME_KEY);


### PR DESCRIPTION
### 🔎 작업 내용

- [x] 다크 토큰 적용 전까지 설정 화면 테마 메뉴 비노출
  - SettingsNav.tsx — 화면 테마 메뉴 비노출
  - themeStore.ts — 강제 light 잠금

- [x] GNB 이슈 수정 #264 
  - 로그인 페이지에서 GNB hide (존재가 무의미함 연결되는 곳이 없음)
  - 사이드 내비게이션 열린 상태에서 화면 스크롤 막기
  - 사이드 내비게이션 열린 상태에서 검색이나 알림 클릭 시 Close
